### PR TITLE
Read API key from env

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ DB_NAME=cakephptest
 DB_USER=cakephptest
 DB_PASS=cakepassword
 DB_PORT=8888
+API_KEY=2f8763d2bb7e41feb2485d92d1e426c4

--- a/html/product_thing/config/app.php
+++ b/html/product_thing/config/app.php
@@ -47,7 +47,7 @@ return [
      *   paths for plugins, view templates and locale files respectively.
      */
     'App' => [
-        'API_KEY'=>'2f8763d2bb7e41feb2485d92d1e426c4',
+        'API_KEY' => env('API_KEY'),
         'namespace' => 'App',
         'encoding' => env('APP_ENCODING', 'UTF-8'),
         'defaultLocale' => env('APP_DEFAULT_LOCALE', 'en_US'),

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -32,7 +32,7 @@ class APIController extends AppController
         $header = array(
             'Content-Type: application/x-www-form-urlencoded',
             'Context-Length: ' . 20,
-            'Ocp-Apim-Subscription-Key: 2f8763d2bb7e41feb2485d92d1e426c4'
+            'Ocp-Apim-Subscription-Key: ' . env('API_KEY')
         );
         $content = array(
             'http' => array(
@@ -97,7 +97,7 @@ class APIController extends AppController
         $header = array(
             'Content-Type: application/x-www-form-urlencoded',
             'Context-Length: ' . 20,
-            'Ocp-Apim-Subscription-Key: 2f8763d2bb7e41feb2485d92d1e426c4'
+            'Ocp-Apim-Subscription-Key: ' . env('API_KEY')
         );
         $content = array(
             'http' => array(
@@ -163,7 +163,7 @@ class APIController extends AppController
         $header = array(
             'Content-Type: application/x-www-form-urlencoded',
             'Context-Length: ' . 20,
-            'Ocp-Apim-Subscription-Key: 2f8763d2bb7e41feb2485d92d1e426c4'
+            'Ocp-Apim-Subscription-Key: ' . env('API_KEY')
         );
 
         $content = array(

--- a/html/product_thing/src/Controller/Component/APIComponent.php
+++ b/html/product_thing/src/Controller/Component/APIComponent.php
@@ -8,7 +8,6 @@ use Cake\Http\Client;
 class APIComponent extends Component
 {
 
-    const API_KEY = '2f8763d2bb7e41feb2485d92d1e426c4';
     const BASE_URL = 'https://www.reinfolib.mlit.go.jp/ex-api/external/XIT001?year=2015&area=13';
 
     public function rEstateAPI(): string|bool
@@ -28,7 +27,7 @@ class APIComponent extends Component
         $header = array(
             "Content-Type: application/x-www-form-urlencoded",
             "Context-Length: " . strlen($data),
-            "Ocp-Apim-Subscription-Key: " . self::API_KEY
+            "Ocp-Apim-Subscription-Key: " . env('API_KEY')
         );
 
         $context = array(


### PR DESCRIPTION
## Summary
- load Dotenv API_KEY into config
- remove hard-coded subscription key usage

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857a9fbbf88833380c5631a23eaf744