### PR TITLE
feat: 国交省APIプロキシコントローラーを実装

### DIFF
--- a/html/product_thing/config/.env.example
+++ b/html/product_thing/config/.env.example
@@ -19,6 +19,7 @@ export APP_ENCODING="UTF-8"
 export APP_DEFAULT_LOCALE="en_US"
 export APP_DEFAULT_TIMEZONE="UTC"
 export SECURITY_SALT="__SALT__"
+export MLIT_API_KEY=""
 
 # Uncomment these to define cache configuration via environment variables.
 #export CACHE_DURATION="+2 minutes"

--- a/html/product_thing/config/routes.php
+++ b/html/product_thing/config/routes.php
@@ -59,6 +59,7 @@ return function (RouteBuilder $routes): void {
          */
 
         $builder->connect('/', ['controller' => 'API', 'action' => 'index']);
+        $builder->connect('/api/mlit/transactions', ['controller' => 'MlitProxy', 'action' => 'transactions']);
         $builder->connect('/API', ['controller' => 'API', 'action' => 'r_EstateAPI']);
         $builder->connect('/API/select_a_p_i', ['controller' => 'API', 'action' => 'selectAPI']);
         $builder->connect(

--- a/html/product_thing/src/Controller/MlitProxyController.php
+++ b/html/product_thing/src/Controller/MlitProxyController.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Cake\Http\Client;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\InternalErrorException;
+
+class MlitProxyController extends AppController
+{
+    private const MLIT_PATH = '/ex-api/external/XIT001';
+
+    private const ALLOWED_QUERY_PARAMS = [
+        'year',
+        'quarter',
+        'city',
+        'area',
+        'priceClassification',
+        'language',
+    ];
+
+    public function transactions()
+    {
+        $this->request->allowMethod(['get']);
+
+        $apiKey = (string)env('MLIT_API_KEY', (string)env('API_KEY', ''));
+        if ($apiKey === '') {
+            throw new InternalErrorException('MLIT API key is not configured.');
+        }
+
+        $query = $this->buildQueryParams();
+        if ($query === []) {
+            throw new BadRequestException('At least one query parameter is required.');
+        }
+
+        $client = new Client([
+            'scheme' => 'https',
+            'host' => 'www.reinfolib.mlit.go.jp',
+            'timeout' => 15,
+        ]);
+
+        $apiResponse = $client->get(self::MLIT_PATH, $query, [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Accept-Encoding' => 'identity',
+                'Ocp-Apim-Subscription-Key' => $apiKey,
+            ],
+        ]);
+
+        return $this->response
+            ->withType('application/json')
+            ->withStatus($apiResponse->getStatusCode())
+            ->withStringBody($apiResponse->getStringBody());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildQueryParams(): array
+    {
+        $query = [];
+        foreach (self::ALLOWED_QUERY_PARAMS as $param) {
+            $value = $this->request->getQuery($param);
+            if ($value === null || $value === '') {
+                continue;
+            }
+            $query[$param] = (string)$value;
+        }
+
+        return $query;
+    }
+}

--- a/html/product_thing/tests/TestCase/Controller/MlitProxyControllerTest.php
+++ b/html/product_thing/tests/TestCase/Controller/MlitProxyControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class MlitProxyControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    public function testTransactionsRequiresQueryParams(): void
+    {
+        $this->get('/api/mlit/transactions');
+        $this->assertResponseCode(400);
+    }
+
+    public function testTransactionsOnlyAllowsGet(): void
+    {
+        $this->post('/api/mlit/transactions');
+        $this->assertResponseCode(405);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #4 の実装として、国交省APIをCakePHP経由で呼び出すプロキシエンドポイントを追加しました。

## 変更内容
- `MlitProxyController::transactions()` を追加（`Http\Client` を使用）
- APIキーを `MLIT_API_KEY`（未設定時は `API_KEY`）から読み込み
- `/api/mlit/transactions` ルートを追加
- `config/.env.example` に `MLIT_API_KEY` を追加
- コントローラテストを追加（400/405）

## 関連Issue
- Closes #4

## 補足
- `composer test` は既存環境の依存関係（Cake Chronos と PHPバージョン互換）に起因する Fatal で実行できない状態です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for accessing transaction data with support for filtering by year, quarter, city, area, price classification, and language.
  * Endpoint requires an API key for authentication and only accepts GET requests.

* **Configuration**
  * Added new environment variable for API key setup.

* **Tests**
  * Added endpoint validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->