### PR TITLE
feat: map platform foundation and API explorer enhancements

### DIFF
--- a/html/product_thing/config/.env.example
+++ b/html/product_thing/config/.env.example
@@ -20,6 +20,7 @@ export APP_DEFAULT_LOCALE="en_US"
 export APP_DEFAULT_TIMEZONE="UTC"
 export SECURITY_SALT="__SALT__"
 export MLIT_API_KEY=""
+export GOOGLE_MAPS_API_KEY=""
 
 # Uncomment these to define cache configuration via environment variables.
 #export CACHE_DURATION="+2 minutes"

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -271,20 +271,41 @@ class APIController extends AppController
 
     public function apiExplorer()
     {
-        $apiOptions = $this->getLibraryApiOptions();
+        $apiCatalog = $this->getLibraryApiCatalog();
+        $apiOptions = [];
+        foreach ($apiCatalog as $item) {
+            $apiOptions[$item['id']] = $item['id'] . ' - ' . $item['name'];
+        }
+
         $selectedApi = 'XIT001';
-        $queryString = 'area=13&city=13101&year=2024';
+        $defaultQueries = [
+            'XIT001' => 'area=13&city=13101&year=2024',
+            'XIT002' => 'area=13&year=2024',
+            'XCT001' => 'area=13&city=13101&year=2024',
+            'XPT001' => 'area=13&city=13101&year=2024',
+            'XPT002' => 'year=2024',
+            'XGT001' => 'lat=35.6812&lon=139.7671&radius=1000',
+            'XST001' => 'lat=35.6812&lon=139.7671&radius=1000',
+        ];
+        $queryString = $defaultQueries[$selectedApi] ?? 'year=2024';
         $resultData = null;
         $rawResult = null;
         $requestUrl = null;
+        $curlExample = null;
         $errorMessage = null;
+        $apiKey = (string)env('API_KEY');
 
         if ($this->request->is('post')) {
             $selectedApi = (string)$this->request->getData('api_id');
             $queryString = trim((string)$this->request->getData('query_string'));
+            if ($queryString === '') {
+                $queryString = $defaultQueries[$selectedApi] ?? 'year=2024';
+            }
 
             if (!isset($apiOptions[$selectedApi])) {
                 $errorMessage = 'API IDが不正です。';
+            } elseif ($apiKey === '') {
+                $errorMessage = 'API_KEY が未設定です。config/.env に設定してください。';
             } else {
                 parse_str($queryString, $queryParams);
                 if (!is_array($queryParams)) {
@@ -297,7 +318,7 @@ class APIController extends AppController
                 $header = [
                     'Content-Type: application/x-www-form-urlencoded',
                     'Context-Length: ' . 20,
-                    'Ocp-Apim-Subscription-Key: ' . env('API_KEY'),
+                    'Ocp-Apim-Subscription-Key: ' . $apiKey,
                 ];
                 $content = [
                     'http' => [
@@ -311,6 +332,7 @@ class APIController extends AppController
 
                 $baseUrl = 'https://www.reinfolib.mlit.go.jp/ex-api/external/' . $selectedApi . '?';
                 $requestUrl = $baseUrl . http_build_query($queryParams);
+                $curlExample = 'curl -s -H "Ocp-Apim-Subscription-Key: ' . $apiKey . '" "' . $requestUrl . '"';
                 $response = file_get_contents($requestUrl, false, $context);
 
                 if ($response === false) {
@@ -336,29 +358,56 @@ class APIController extends AppController
         }
 
         $this->set(compact(
+            'apiCatalog',
             'apiOptions',
             'selectedApi',
             'queryString',
             'resultData',
             'rawResult',
             'requestUrl',
+            'curlExample',
             'errorMessage'
         ));
     }
 
-    private function getLibraryApiOptions(): array
+    private function getLibraryApiCatalog(): array
     {
         return [
-            'XIT001' => '不動産価格（取引価格・成約価格）情報取得API',
-            'XPT001' => '不動産価格情報のポイント (点) API',
-            'XPT002' => '地価公示・地価調査のポイント (点) API',
-            'XCT001' => '鑑定評価書情報API',
-            'XKT002' => '都市計画決定GISデータ（用途地域）API',
-            'XKT010' => '国土数値情報（医療機関）API',
-            'XKT016' => '国土数値情報（災害危険区域）API',
-            'XKT026' => '国土数値情報（洪水浸水想定区域）API',
-            'XGT001' => '指定緊急避難場所API',
-            'XST001' => '災害履歴API',
+            ['id' => 'XIT001', 'category' => '価格情報', 'name' => '不動産価格（取引価格・成約価格）情報取得API', 'source' => '不動産取引価格情報 / 成約価格情報'],
+            ['id' => 'XIT002', 'category' => '市区町村情報', 'name' => '都道府県内市区町村一覧取得API', 'source' => '全国地方公共団体コード準拠'],
+            ['id' => 'XCT001', 'category' => '価格情報', 'name' => '鑑定評価書情報API', 'source' => '地価公示（鑑定評価書）'],
+            ['id' => 'XPT001', 'category' => '価格情報', 'name' => '不動産価格情報のポイント (点) API', 'source' => '不動産取引価格情報 / 成約価格情報'],
+            ['id' => 'XPT002', 'category' => '価格情報', 'name' => '地価公示・地価調査のポイント (点) API', 'source' => '地価公示 / 地価調査'],
+            ['id' => 'XKT001', 'category' => '都市計画情報', 'name' => '都市計画区域/区域区分 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT002', 'category' => '都市計画情報', 'name' => '用途地域 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT003', 'category' => '都市計画情報', 'name' => '立地適正化計画 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT004', 'category' => '周辺施設情報', 'name' => '小学校区 API', 'source' => '国土数値情報（小学校区）'],
+            ['id' => 'XKT005', 'category' => '周辺施設情報', 'name' => '中学校区 API', 'source' => '国土数値情報（中学校区）'],
+            ['id' => 'XKT006', 'category' => '周辺施設情報', 'name' => '学校 API', 'source' => '国土数値情報（学校）'],
+            ['id' => 'XKT007', 'category' => '周辺施設情報', 'name' => '保育園・幼稚園等 API', 'source' => '国土数値情報（学校・福祉施設加工）'],
+            ['id' => 'XKT010', 'category' => '周辺施設情報', 'name' => '医療機関 API', 'source' => '国土数値情報（医療機関）'],
+            ['id' => 'XKT011', 'category' => '周辺施設情報', 'name' => '福祉施設 API', 'source' => '国土数値情報（福祉施設）'],
+            ['id' => 'XKT013', 'category' => '人口情報等', 'name' => '将来推計人口250mメッシュ API', 'source' => '国土数値情報（250mメッシュ別将来推計人口）'],
+            ['id' => 'XKT014', 'category' => '都市計画情報', 'name' => '防火・準防火地域 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT015', 'category' => '人口情報等', 'name' => '駅別乗降客数 API', 'source' => '国土数値情報（駅別乗降客数）'],
+            ['id' => 'XKT016', 'category' => '防災情報', 'name' => '災害危険区域 API', 'source' => '国土数値情報（災害危険区域）'],
+            ['id' => 'XKT017', 'category' => '周辺施設情報', 'name' => '図書館 API', 'source' => '国土数値情報（文化施設加工）'],
+            ['id' => 'XKT018', 'category' => '周辺施設情報', 'name' => '市区町村役場及び集会施設等 API', 'source' => '国土数値情報（市町村役場等及び公的集会施設）'],
+            ['id' => 'XKT019', 'category' => '周辺施設情報', 'name' => '自然公園地域 API', 'source' => '国土数値情報（自然公園地域）'],
+            ['id' => 'XKT020', 'category' => '地形情報', 'name' => '大規模盛土造成地マップ API', 'source' => '国土数値情報（大規模盛土造成地）'],
+            ['id' => 'XKT021', 'category' => '防災情報', 'name' => '地すべり防止地区 API', 'source' => '国土数値情報（地すべり防止区域）'],
+            ['id' => 'XKT022', 'category' => '防災情報', 'name' => '急傾斜地崩壊危険区域 API', 'source' => '国土数値情報（急傾斜地崩壊危険区域）'],
+            ['id' => 'XKT023', 'category' => '都市計画情報', 'name' => '地区計画 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT024', 'category' => '都市計画情報', 'name' => '高度利用地区 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT025', 'category' => '防災情報', 'name' => '液状化の発生傾向図 API', 'source' => '国土交通省都市局'],
+            ['id' => 'XKT026', 'category' => '防災情報', 'name' => '洪水浸水想定区域 API', 'source' => '国土数値情報（洪水浸水想定区域）'],
+            ['id' => 'XKT027', 'category' => '防災情報', 'name' => '高潮浸水想定区域 API', 'source' => '国土数値情報（高潮浸水想定区域）'],
+            ['id' => 'XKT028', 'category' => '防災情報', 'name' => '津波浸水想定 API', 'source' => '国土数値情報（津波浸水想定）'],
+            ['id' => 'XKT029', 'category' => '防災情報', 'name' => '土砂災害警戒区域 API', 'source' => '国土数値情報（土砂災害警戒区域）'],
+            ['id' => 'XKT030', 'category' => '都市計画情報', 'name' => '都市計画道路 API', 'source' => '都市計画決定GISデータ（令和6年度）'],
+            ['id' => 'XKT031', 'category' => '人口情報等', 'name' => '人口集中地区 API', 'source' => '国土数値情報（人口集中地区データ）'],
+            ['id' => 'XGT001', 'category' => '防災情報', 'name' => '指定緊急避難場所 API', 'source' => '国土地理院GISデータ'],
+            ['id' => 'XST001', 'category' => '防災情報', 'name' => '災害履歴 API', 'source' => '国土調査（土地履歴調査）'],
         ];
     }
 

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -220,6 +220,7 @@ class APIController extends AppController
         $this->set('limit', $limit);
         $this->set('total', $total);
         $this->set('pages', ceil($total / $limit));
+        $this->set('googleMapsApiKey', env('GOOGLE_MAPS_API_KEY') ?: null);
 
     }
     /** */

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -176,25 +176,70 @@ class APIController extends AppController
         );
         $context = stream_context_create($content);
 
+        $decodeResponse = function ($response) {
+            if (!is_string($response) || $response === '') {
+                return null;
+            }
 
+            $decodedBody = $response;
+            if (substr($response, 0, 2) === "\x1f\x8b") {
+                $inflated = gzdecode($response);
+                if ($inflated !== false) {
+                    $decodedBody = $inflated;
+                }
+            }
+
+            $json = json_decode($decodedBody, true);
+            return is_array($json) ? $json : null;
+        };
 
         $response = file_get_contents($base_url . http_build_query($query), false, $context);
-        $return = true;
-
         if ($response === false) {
-            $return = false;
-            $data= array();
             error_log('APIからのデータ取得に失敗しました。');
-            // ここでエラーメッセージを設定または例外を投げる
             throw new \Exception("APIからのデータ取得に失敗しました。");
         }
-        if($response === '{"message":"検索結果がありません。"}'){
-            $return = false;
-            $data  = array();
+
+        $data = $decodeResponse($response) ?? [];
+        if (isset($data['message']) && $data['message'] === '検索結果がありません。') {
+            $data = [];
         }
 
-        if($return) {
-            $data = json_decode(gzdecode($response), true);
+        if (isset($data['data']) && is_array($data['data'])) {
+            $pointBaseUrl = 'https://www.reinfolib.mlit.go.jp/ex-api/external/XPT001?';
+            $pointResponse = file_get_contents($pointBaseUrl . http_build_query($query), false, $context);
+            $pointData = $decodeResponse($pointResponse);
+
+            if (is_array($pointData) && isset($pointData['data']) && is_array($pointData['data'])) {
+                $pointRows = array_values($pointData['data']);
+                $extractCoordinateValue = function (array $row, array $keys) {
+                    foreach ($keys as $key) {
+                        if (isset($row[$key]) && $row[$key] !== '') {
+                            return $row[$key];
+                        }
+                    }
+
+                    return null;
+                };
+
+                $longitudeKeys = ['Longitude', 'longitude', 'lng', 'Lon', 'LON', 'x'];
+                $latitudeKeys = ['Latitude', 'latitude', 'lat', 'Lat', 'LAT', 'y'];
+
+                foreach ($data['data'] as $index => &$record) {
+                    if (!is_array($record) || !isset($pointRows[$index]) || !is_array($pointRows[$index])) {
+                        continue;
+                    }
+
+                    $pointRecord = $pointRows[$index];
+                    $longitude = $extractCoordinateValue($pointRecord, $longitudeKeys);
+                    $latitude = $extractCoordinateValue($pointRecord, $latitudeKeys);
+
+                    if ($longitude !== null && $latitude !== null) {
+                        $record['Longitude'] = $longitude;
+                        $record['Latitude'] = $latitude;
+                    }
+                }
+                unset($record);
+            }
         }
 
 

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -268,6 +268,100 @@ class APIController extends AppController
         $this->set('googleMapsApiKey', env('GOOGLE_MAPS_API_KEY') ?: null);
 
     }
+
+    public function apiExplorer()
+    {
+        $apiOptions = $this->getLibraryApiOptions();
+        $selectedApi = 'XIT001';
+        $queryString = 'area=13&city=13101&year=2024';
+        $resultData = null;
+        $rawResult = null;
+        $requestUrl = null;
+        $errorMessage = null;
+
+        if ($this->request->is('post')) {
+            $selectedApi = (string)$this->request->getData('api_id');
+            $queryString = trim((string)$this->request->getData('query_string'));
+
+            if (!isset($apiOptions[$selectedApi])) {
+                $errorMessage = 'API IDが不正です。';
+            } else {
+                parse_str($queryString, $queryParams);
+                if (!is_array($queryParams)) {
+                    $queryParams = [];
+                }
+                $queryParams = array_filter($queryParams, function ($value) {
+                    return is_scalar($value) && trim((string)$value) !== '';
+                });
+
+                $header = [
+                    'Content-Type: application/x-www-form-urlencoded',
+                    'Context-Length: ' . 20,
+                    'Ocp-Apim-Subscription-Key: ' . env('API_KEY'),
+                ];
+                $content = [
+                    'http' => [
+                        'method' => 'GET',
+                        'header' => implode("\r\n", $header),
+                        'content' => '',
+                        'ignore_errors' => true,
+                    ],
+                ];
+                $context = stream_context_create($content);
+
+                $baseUrl = 'https://www.reinfolib.mlit.go.jp/ex-api/external/' . $selectedApi . '?';
+                $requestUrl = $baseUrl . http_build_query($queryParams);
+                $response = file_get_contents($requestUrl, false, $context);
+
+                if ($response === false) {
+                    $errorMessage = 'APIレスポンスの取得に失敗しました。';
+                } else {
+                    $decodedBody = $response;
+                    if (substr($response, 0, 2) === "\x1f\x8b") {
+                        $inflated = gzdecode($response);
+                        if ($inflated !== false) {
+                            $decodedBody = $inflated;
+                        }
+                    }
+                    $resultData = json_decode($decodedBody, true);
+
+                    if (!is_array($resultData)) {
+                        $errorMessage = 'JSONの解析に失敗しました。';
+                        $resultData = null;
+                    } else {
+                        $rawResult = json_encode($resultData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                    }
+                }
+            }
+        }
+
+        $this->set(compact(
+            'apiOptions',
+            'selectedApi',
+            'queryString',
+            'resultData',
+            'rawResult',
+            'requestUrl',
+            'errorMessage'
+        ));
+    }
+
+    private function getLibraryApiOptions(): array
+    {
+        return [
+            'XIT001' => '不動産価格（取引価格・成約価格）情報取得API',
+            'XPT001' => '不動産価格情報のポイント (点) API',
+            'XPT002' => '地価公示・地価調査のポイント (点) API',
+            'XCT001' => '鑑定評価書情報API',
+            'XKT002' => '都市計画決定GISデータ（用途地域）API',
+            'XKT010' => '国土数値情報（医療機関）API',
+            'XKT016' => '国土数値情報（災害危険区域）API',
+            'XKT026' => '国土数値情報（洪水浸水想定区域）API',
+            'XGT001' => '指定緊急避難場所API',
+            'XST001' => '災害履歴API',
+        ];
+    }
+
     /** */
     public function getPrefectures()
     {

--- a/html/product_thing/templates/API/api_explorer.php
+++ b/html/product_thing/templates/API/api_explorer.php
@@ -9,7 +9,7 @@
 <body>
 <div class="container mt-5 mb-5">
     <h1 class="mb-3">不動産情報ライブラリ API探索（別機能）</h1>
-    <p class="text-muted">API IDとクエリを指定して、レスポンスを確認できます。</p>
+    <p class="text-muted">デベロッパー向けに、全API IDを選んで実行URL・cURL・JSONレスポンスを確認できます。</p>
 
     <div class="mb-3">
         <?= $this->Html->link('価格情報画面に戻る', ['controller' => 'API', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary']) ?>
@@ -32,7 +32,7 @@
     </div>
     <div class="form-group">
         <?= $this->Form->control('query_string', [
-            'label' => 'クエリ文字列（例: area=13&city=13101&year=2024）',
+            'label' => 'クエリ文字列（例: area=13&city=13101&year=2024 / lat=35.6812&lon=139.7671&radius=1000）',
             'type' => 'text',
             'value' => $queryString,
             'class' => 'form-control',
@@ -46,6 +46,10 @@
         <hr>
         <h2 class="h5">実行URL</h2>
         <code><?= h($requestUrl) ?></code>
+        <?php if (!empty($curlExample)): ?>
+            <h2 class="h5 mt-3">cURLサンプル</h2>
+            <pre class="bg-light p-3"><?= h($curlExample) ?></pre>
+        <?php endif; ?>
     <?php endif; ?>
 
     <?php if (is_array($resultData)): ?>
@@ -64,6 +68,31 @@
             <pre class="bg-light p-3 mt-2" style="max-height: 540px; overflow: auto;"><?= h($rawResult) ?></pre>
         </details>
     <?php endif; ?>
+
+    <hr>
+    <h2 class="h5 mb-3">利用可能APIカタログ</h2>
+    <div class="table-responsive">
+        <table class="table table-sm table-bordered table-striped">
+            <thead class="thead-dark">
+            <tr>
+                <th>ID</th>
+                <th>分類</th>
+                <th>API名</th>
+                <th>出典・整備情報</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($apiCatalog as $api): ?>
+                <tr>
+                    <td><code><?= h($api['id']) ?></code></td>
+                    <td><?= h($api['category']) ?></td>
+                    <td><?= h($api['name']) ?></td>
+                    <td><?= h($api['source']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
 </div>
 </body>
 </html>

--- a/html/product_thing/templates/API/api_explorer.php
+++ b/html/product_thing/templates/API/api_explorer.php
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>不動産情報ライブラリ API探索</title>
+    <?= $this->Html->css('https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css') ?>
+</head>
+<body>
+<div class="container mt-5 mb-5">
+    <h1 class="mb-3">不動産情報ライブラリ API探索（別機能）</h1>
+    <p class="text-muted">API IDとクエリを指定して、レスポンスを確認できます。</p>
+
+    <div class="mb-3">
+        <?= $this->Html->link('価格情報画面に戻る', ['controller' => 'API', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary']) ?>
+    </div>
+
+    <?php if (!empty($errorMessage)): ?>
+        <div class="alert alert-danger"><?= h($errorMessage) ?></div>
+    <?php endif; ?>
+
+    <?= $this->Form->create(null, ['url' => ['action' => 'apiExplorer']]) ?>
+    <div class="form-group">
+        <?= $this->Form->control('api_id', [
+            'label' => 'API ID',
+            'type' => 'select',
+            'options' => $apiOptions,
+            'default' => $selectedApi,
+            'class' => 'form-control',
+            'required' => true,
+        ]) ?>
+    </div>
+    <div class="form-group">
+        <?= $this->Form->control('query_string', [
+            'label' => 'クエリ文字列（例: area=13&city=13101&year=2024）',
+            'type' => 'text',
+            'value' => $queryString,
+            'class' => 'form-control',
+            'required' => true,
+        ]) ?>
+    </div>
+    <?= $this->Form->button('APIを実行', ['class' => 'btn btn-primary']) ?>
+    <?= $this->Form->end() ?>
+
+    <?php if (!empty($requestUrl)): ?>
+        <hr>
+        <h2 class="h5">実行URL</h2>
+        <code><?= h($requestUrl) ?></code>
+    <?php endif; ?>
+
+    <?php if (is_array($resultData)): ?>
+        <hr>
+        <h2 class="h5">レスポンス概要</h2>
+        <p class="mb-2">
+            件数:
+            <?php if (isset($resultData['data']) && is_array($resultData['data'])): ?>
+                <?= count($resultData['data']) ?>
+            <?php else: ?>
+                data配列なし
+            <?php endif; ?>
+        </p>
+        <details open>
+            <summary>レスポンスJSON</summary>
+            <pre class="bg-light p-3 mt-2" style="max-height: 540px; overflow: auto;"><?= h($rawResult) ?></pre>
+        </details>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>不動産取引価格情報</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link href="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.css" rel="stylesheet">
     <style>
         .table th, .table td {
             vertical-align: middle;
@@ -13,6 +14,11 @@
             background-color: #343a40;
             color: #fff;
         }
+        #map {
+            width: 100%;
+            height: 420px;
+            border-radius: 8px;
+        }
     </style>
 </head>
 <body>
@@ -20,6 +26,11 @@
     <h1 class="mb-4 text-center">
         不動産取引価格情報
     </h1>
+
+    <div class="mb-4">
+        <h2 class="h5 mb-3">地図表示</h2>
+        <div id="map" aria-label="不動産データの地図"></div>
+    </div>
 
     <div class="row mb-4">
         <div class="col-md-6 offset-md-3">
@@ -109,8 +120,18 @@
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<script src="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.js"></script>
 <script>
     document.addEventListener('DOMContentLoaded', (event) => {
+        const defaultCenter = [139.7671, 35.6812];
+        const defaultZoom = 10;
+        new maplibregl.Map({
+            container: 'map',
+            style: 'https://demotiles.maplibre.org/style.json',
+            center: defaultCenter,
+            zoom: defaultZoom
+        });
+
         const searchInput = document.getElementById('searchInput');
         searchInput.addEventListener('keyup', function () {
             const filter = searchInput.value.toLowerCase();

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -30,6 +30,9 @@
     <div class="mb-4">
         <h2 class="h5 mb-3">地図表示</h2>
         <div id="map" aria-label="不動産データの地図"></div>
+        <div id="mapStatus" class="alert alert-secondary mt-3 mb-0">
+            地図を準備中です。
+        </div>
     </div>
 
     <div class="row mb-4">
@@ -121,15 +124,215 @@
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 <script src="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.js"></script>
+<?php
+$mapRecords = [];
+if (!empty($data) && is_array($data)) {
+    foreach ($data as $record) {
+        if (is_array($record)) {
+            $mapRecords[] = $record;
+        }
+    }
+}
+?>
 <script>
     document.addEventListener('DOMContentLoaded', (event) => {
         const defaultCenter = [139.7671, 35.6812];
         const defaultZoom = 10;
-        new maplibregl.Map({
+        const map = new maplibregl.Map({
             container: 'map',
-            style: 'https://demotiles.maplibre.org/style.json',
+            style: {
+                version: 8,
+                sources: {
+                    osm: {
+                        type: 'raster',
+                        tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                        tileSize: 256,
+                        attribution: '&copy; OpenStreetMap contributors'
+                    }
+                },
+                layers: [
+                    {
+                        id: 'osm',
+                        type: 'raster',
+                        source: 'osm'
+                    }
+                ]
+            },
             center: defaultCenter,
             zoom: defaultZoom
+        });
+        map.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+        const mapStatus = document.getElementById('mapStatus');
+        const records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+
+        const setMapStatus = function (message, variant) {
+            const color = variant || 'secondary';
+            mapStatus.className = 'alert alert-' + color + ' mt-3 mb-0';
+            mapStatus.textContent = message;
+        };
+
+        const sleep = function (ms) {
+            return new Promise(function (resolve) {
+                setTimeout(resolve, ms);
+            });
+        };
+
+        const extractCoordinates = function (record) {
+            const pairs = [
+                ['Longitude', 'Latitude'],
+                ['longitude', 'latitude'],
+                ['lng', 'lat'],
+                ['Lon', 'Lat'],
+                ['LON', 'LAT']
+            ];
+            for (const pair of pairs) {
+                const lng = Number(record[pair[0]]);
+                const lat = Number(record[pair[1]]);
+                if (Number.isFinite(lng) && Number.isFinite(lat)) {
+                    return [lng, lat];
+                }
+            }
+
+            return null;
+        };
+
+        const buildAddress = function (record) {
+            const parts = [
+                record.Prefecture,
+                record.Municipality,
+                record.DistrictName
+            ].filter(function (value) {
+                return value && value !== 'N/A';
+            });
+
+            return parts.length > 0 ? parts.join('') : null;
+        };
+
+        const geocodeAddress = async function (address) {
+            const endpoint = 'https://msearch.gsi.go.jp/address-search/AddressSearch?q=' + encodeURIComponent(address);
+            const response = await fetch(endpoint);
+            if (!response.ok) {
+                return null;
+            }
+            const geoJson = await response.json();
+            if (!Array.isArray(geoJson) || geoJson.length === 0) {
+                return null;
+            }
+            const coordinates = geoJson[0] && geoJson[0].geometry ? geoJson[0].geometry.coordinates : null;
+            if (!Array.isArray(coordinates) || coordinates.length !== 2) {
+                return null;
+            }
+
+            return coordinates;
+        };
+
+        const toPriceNumber = function (value) {
+            if (typeof value === 'number') {
+                return value;
+            }
+            if (typeof value === 'string') {
+                return Number(value.replace(/[^\d.-]/g, ''));
+            }
+
+            return NaN;
+        };
+
+        const priceToColor = function (price) {
+            if (!Number.isFinite(price)) {
+                return '#2563eb';
+            }
+            if (price >= 100000000) {
+                return '#b91c1c';
+            }
+            if (price >= 50000000) {
+                return '#ea580c';
+            }
+            if (price >= 30000000) {
+                return '#f59e0b';
+            }
+
+            return '#16a34a';
+        };
+
+        const escapeHtml = function (value) {
+            return String(value || '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        };
+
+        const renderMapPoints = async function () {
+            if (!Array.isArray(records) || records.length === 0) {
+                setMapStatus('表示対象データがありません。', 'warning');
+                return;
+            }
+
+            setMapStatus('取引データから地図ポイントを作成中です。', 'secondary');
+
+            const geocodeCache = new Map();
+            const geocodeLimit = 20;
+            let geocodeCount = 0;
+            let plottedCount = 0;
+            const bounds = new maplibregl.LngLatBounds();
+
+            for (const record of records) {
+                let coordinates = extractCoordinates(record);
+                if (!coordinates && geocodeCount < geocodeLimit) {
+                    const address = buildAddress(record);
+                    if (address) {
+                        if (geocodeCache.has(address)) {
+                            coordinates = geocodeCache.get(address);
+                        } else {
+                            coordinates = await geocodeAddress(address);
+                            geocodeCache.set(address, coordinates);
+                            geocodeCount += 1;
+                            await sleep(200);
+                        }
+                    }
+                }
+                if (!coordinates) {
+                    continue;
+                }
+
+                const price = toPriceNumber(record.TradePrice);
+                const formattedPrice = Number.isFinite(price) ? price.toLocaleString() + ' 円' : 'N/A';
+                const marker = new maplibregl.Marker({color: priceToColor(price)})
+                    .setLngLat(coordinates)
+                    .setPopup(new maplibregl.Popup({offset: 25}).setHTML(
+                        '<div>' +
+                        '<strong>' + escapeHtml(record.Prefecture) + ' ' + escapeHtml(record.Municipality) + '</strong><br>' +
+                        '地区: ' + escapeHtml(record.DistrictName || 'N/A') + '<br>' +
+                        '価格: ' + escapeHtml(formattedPrice) + '<br>' +
+                        '時期: ' + escapeHtml(record.Period || 'N/A') +
+                        '</div>'
+                    ))
+                    .addTo(map);
+
+                if (marker) {
+                    plottedCount += 1;
+                    bounds.extend(coordinates);
+                }
+            }
+
+            if (plottedCount === 0) {
+                setMapStatus('位置情報を取得できるデータがなく、地図上に表示できませんでした。', 'warning');
+                return;
+            }
+
+            map.fitBounds(bounds, {
+                padding: 40,
+                maxZoom: 13
+            });
+            setMapStatus('地図に ' + plottedCount + ' 件の取引データを表示しました。', 'success');
+        };
+
+        map.on('load', function () {
+            renderMapPoints().catch(function () {
+                setMapStatus('地図データの表示中にエラーが発生しました。', 'danger');
+            });
         });
 
         const searchInput = document.getElementById('searchInput');

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -19,6 +19,9 @@
             height: 420px;
             border-radius: 8px;
         }
+        .mode-btn.is-active {
+            font-weight: 700;
+        }
     </style>
 </head>
 <body>
@@ -29,6 +32,20 @@
 
     <div class="mb-4">
         <h2 class="h5 mb-3">地図表示</h2>
+        <div class="d-flex flex-wrap align-items-center mb-3">
+            <span class="mr-3">分析モード:</span>
+            <div class="btn-group btn-group-sm" role="group" aria-label="mode-switch">
+                <button type="button" class="btn btn-outline-primary mode-btn is-active" data-mode="living">お買い物・生活</button>
+                <button type="button" class="btn btn-outline-danger mode-btn" data-mode="safety">安心・防災</button>
+                <button type="button" class="btn btn-outline-dark mode-btn" data-mode="invest">プロ・投資</button>
+            </div>
+        </div>
+        <div class="card mb-3">
+            <div class="card-body p-3">
+                <h3 class="h6 mb-2">レイヤー表示</h3>
+                <div id="layerControls" class="mb-0"></div>
+            </div>
+        </div>
         <div id="map" aria-label="不動産データの地図"></div>
         <div id="mapStatus" class="alert alert-secondary mt-3 mb-0">
             地図を準備中です。
@@ -154,11 +171,78 @@ if (!empty($data) && is_array($data)) {
         const useGoogleMaps = Boolean(googleMapsApiKey && window.google && window.google.maps);
         const mapStatus = document.getElementById('mapStatus');
         const records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        const layerControls = document.getElementById('layerControls');
+        const modeButtons = document.querySelectorAll('.mode-btn');
+        const modeName = {
+            living: 'お買い物・生活',
+            safety: '安心・防災',
+            invest: 'プロ・投資'
+        };
+        const layerCatalog = [
+            {id: 'price-points', label: '取引価格ポイント', available: true},
+            {id: 'facility-poi', label: '生活施設レイヤー（準備中）', available: false},
+            {id: 'hazard-zones', label: '防災リスクレイヤー（準備中）', available: false},
+            {id: 'urban-plan', label: '都市計画レイヤー（準備中）', available: false},
+            {id: 'population-heat', label: '人口ヒートマップ（準備中）', available: false},
+            {id: 'nature-parks', label: '自然環境レイヤー（準備中）', available: false}
+        ];
+        const modeDefaults = {
+            living: ['price-points', 'facility-poi'],
+            safety: ['price-points', 'hazard-zones'],
+            invest: ['price-points', 'urban-plan', 'population-heat']
+        };
+        let currentMode = 'living';
+        const activeLayers = new Set(modeDefaults[currentMode]);
+        const layerMarkerRegistry = {
+            'price-points': []
+        };
 
         const setMapStatus = function (message, variant) {
             const color = variant || 'secondary';
             mapStatus.className = 'alert alert-' + color + ' mt-3 mb-0';
             mapStatus.textContent = message;
+        };
+
+        const syncModeButtons = function () {
+            modeButtons.forEach(function (button) {
+                button.classList.toggle('is-active', button.dataset.mode === currentMode);
+            });
+        };
+
+        const applyLayerVisibility = function () {
+            Object.keys(layerMarkerRegistry).forEach(function (layerId) {
+                const visible = activeLayers.has(layerId);
+                layerMarkerRegistry[layerId].forEach(function (markerWrapper) {
+                    markerWrapper.setVisible(visible);
+                });
+            });
+        };
+
+        const renderLayerControls = function () {
+            let html = '';
+            layerCatalog.forEach(function (layer) {
+                const checked = activeLayers.has(layer.id) ? 'checked' : '';
+                const disabled = layer.available ? '' : 'disabled';
+                const muted = layer.available ? '' : ' text-muted';
+                html += '<div class="form-check mb-1' + muted + '">';
+                html += '<input class="form-check-input layer-toggle" type="checkbox" id="layer-' + layer.id + '" data-layer-id="' + layer.id + '" ' + checked + ' ' + disabled + '>';
+                html += '<label class="form-check-label" for="layer-' + layer.id + '">' + layer.label + '</label>';
+                html += '</div>';
+            });
+            layerControls.innerHTML = html;
+
+            const checkboxes = layerControls.querySelectorAll('.layer-toggle');
+            checkboxes.forEach(function (checkbox) {
+                checkbox.addEventListener('change', function () {
+                    const targetLayerId = checkbox.dataset.layerId;
+                    if (checkbox.checked) {
+                        activeLayers.add(targetLayerId);
+                    } else {
+                        activeLayers.delete(targetLayerId);
+                    }
+                    applyLayerVisibility();
+                });
+            });
         };
 
         const sleep = function (ms) {
@@ -301,6 +385,11 @@ if (!empty($data) && is_array($data)) {
                                 shouldFocus: false
                             });
                         });
+                        return {
+                            setVisible: function (isVisible) {
+                                marker.setMap(isVisible ? googleMap : null);
+                            }
+                        };
                     },
                     fitToBounds: function (plottedCoordinates) {
                         const bounds = new google.maps.LatLngBounds();
@@ -342,10 +431,15 @@ if (!empty($data) && is_array($data)) {
                     maplibreMap.on('load', callback);
                 },
                 addPoint: function (record, coordinates, color, popupHtml) {
-                    new maplibregl.Marker({color: color})
+                    const marker = new maplibregl.Marker({color: color})
                         .setLngLat(coordinates)
                         .setPopup(new maplibregl.Popup({offset: 25}).setHTML(popupHtml))
                         .addTo(maplibreMap);
+                    return {
+                        setVisible: function (isVisible) {
+                            marker.getElement().style.display = isVisible ? '' : 'none';
+                        }
+                    };
                 },
                 fitToBounds: function (plottedCoordinates) {
                     const bounds = new maplibregl.LngLatBounds();
@@ -366,11 +460,7 @@ if (!empty($data) && is_array($data)) {
                 return;
             }
 
-            if (useGoogleMaps) {
-                setMapStatus('Google Mapsで表示中です。Pegman を使って Street View を表示できます。', 'info');
-            } else {
-                setMapStatus('MapLibreで表示中です。Google Maps APIキーを設定すると Pegman を利用できます。', 'secondary');
-            }
+            setMapStatus(modeName[currentMode] + 'モードでレイヤーを準備中です。', 'secondary');
 
             const geocodeCache = new Map();
             const geocodeLimit = 20;
@@ -400,7 +490,8 @@ if (!empty($data) && is_array($data)) {
                 const price = toPriceNumber(record.TradePrice);
                 const formattedPrice = Number.isFinite(price) ? price.toLocaleString() + ' 円' : 'N/A';
                 const popupHtml = createPopupHtml(record, formattedPrice);
-                mapAdapter.addPoint(record, coordinates, priceToColor(price), popupHtml);
+                const markerWrapper = mapAdapter.addPoint(record, coordinates, priceToColor(price), popupHtml);
+                layerMarkerRegistry['price-points'].push(markerWrapper);
                 plottedCount += 1;
                 plottedCoordinates.push(coordinates);
             }
@@ -411,12 +502,27 @@ if (!empty($data) && is_array($data)) {
             }
 
             mapAdapter.fitToBounds(plottedCoordinates);
-            if (useGoogleMaps) {
-                setMapStatus('Google Mapsに ' + plottedCount + ' 件を表示しました。PegmanでStreet View表示が可能です。', 'success');
-            } else {
-                setMapStatus('MapLibreに ' + plottedCount + ' 件を表示しました。', 'success');
-            }
+            applyLayerVisibility();
+            const mapText = useGoogleMaps ? 'Google Maps（Street View利用可）' : 'MapLibre';
+            setMapStatus(modeName[currentMode] + 'モードで ' + plottedCount + ' 件を表示中です（' + mapText + '）。', 'success');
         };
+
+        modeButtons.forEach(function (button) {
+            button.addEventListener('click', function () {
+                currentMode = button.dataset.mode;
+                activeLayers.clear();
+                (modeDefaults[currentMode] || []).forEach(function (layerId) {
+                    activeLayers.add(layerId);
+                });
+                syncModeButtons();
+                renderLayerControls();
+                applyLayerVisibility();
+                setMapStatus(modeName[currentMode] + 'モードに切り替えました。', 'info');
+            });
+        });
+
+        syncModeButtons();
+        renderLayerControls();
 
         mapAdapter.ready(function () {
             renderMapPoints().catch(function () {

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -72,6 +72,10 @@
                     <th class="text-center bg-success">地区名</th>
                     <th class="text-center bg-success">取引価格 (円)</th>
                     <th class="text-center bg-success">面積 (m²)</th>
+                    <th class="text-center bg-success">建築年</th>
+                    <th class="text-center bg-success">間取り</th>
+                    <th class="text-center bg-success">建物構造</th>
+                    <th class="text-center bg-success">用途</th>
                     <th class="text-center bg-success">取引時期</th>
                 </tr>
                 </thead>
@@ -86,11 +90,15 @@
                             <td class="text-center"><?= htmlspecialchars($record['DistrictName'] ?? 'N/A'); ?></td>
                             <td class="text-right"><?= htmlspecialchars(isset($record['TradePrice']) ? number_format($record['TradePrice']) . ' 円' : 'N/A'); ?></td>
                             <td class="text-right"><?= htmlspecialchars($record['Area'] ?? 'N/A'); ?> m²</td>
+                            <td class="text-center"><?= htmlspecialchars($record['BuildingYear'] ?? 'N/A'); ?></td>
+                            <td class="text-center"><?= htmlspecialchars($record['FloorPlan'] ?? 'N/A'); ?></td>
+                            <td class="text-center"><?= htmlspecialchars($record['Structure'] ?? 'N/A'); ?></td>
+                            <td class="text-center"><?= htmlspecialchars($record['Purpose'] ?? 'N/A'); ?></td>
                             <td class="text-center"><?= htmlspecialchars($record['Period'] ?? 'N/A'); ?></td>
                         </tr>
                     <?php else: ?>
                         <tr>
-                            <td colspan="8">Invalid data format: <?= htmlspecialchars($record); ?></td>
+                            <td colspan="12">Invalid data format: <?= htmlspecialchars($record); ?></td>
                         </tr>
                     <?php endif; ?>
                 <?php endforeach; ?>
@@ -306,6 +314,10 @@ if (!empty($data) && is_array($data)) {
                         '<strong>' + escapeHtml(record.Prefecture) + ' ' + escapeHtml(record.Municipality) + '</strong><br>' +
                         '地区: ' + escapeHtml(record.DistrictName || 'N/A') + '<br>' +
                         '価格: ' + escapeHtml(formattedPrice) + '<br>' +
+                        '建築年: ' + escapeHtml(record.BuildingYear || 'N/A') + '<br>' +
+                        '間取り: ' + escapeHtml(record.FloorPlan || 'N/A') + '<br>' +
+                        '建物構造: ' + escapeHtml(record.Structure || 'N/A') + '<br>' +
+                        '用途: ' + escapeHtml(record.Purpose || 'N/A') + '<br>' +
                         '時期: ' + escapeHtml(record.Period || 'N/A') +
                         '</div>'
                     ))

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -131,7 +131,11 @@
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<?php if (!empty($googleMapsApiKey)): ?>
+<script src="https://maps.googleapis.com/maps/api/js?key=<?= urlencode($googleMapsApiKey) ?>&libraries=streetView"></script>
+<?php else: ?>
 <script src="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.js"></script>
+<?php endif; ?>
 <?php
 $mapRecords = [];
 if (!empty($data) && is_array($data)) {
@@ -146,31 +150,8 @@ if (!empty($data) && is_array($data)) {
     document.addEventListener('DOMContentLoaded', (event) => {
         const defaultCenter = [139.7671, 35.6812];
         const defaultZoom = 10;
-        const map = new maplibregl.Map({
-            container: 'map',
-            style: {
-                version: 8,
-                sources: {
-                    osm: {
-                        type: 'raster',
-                        tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-                        tileSize: 256,
-                        attribution: '&copy; OpenStreetMap contributors'
-                    }
-                },
-                layers: [
-                    {
-                        id: 'osm',
-                        type: 'raster',
-                        source: 'osm'
-                    }
-                ]
-            },
-            center: defaultCenter,
-            zoom: defaultZoom
-        });
-        map.addControl(new maplibregl.NavigationControl(), 'top-right');
-
+        const googleMapsApiKey = <?= json_encode($googleMapsApiKey ?? null, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        const useGoogleMaps = Boolean(googleMapsApiKey && window.google && window.google.maps);
         const mapStatus = document.getElementById('mapStatus');
         const records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 
@@ -272,19 +253,130 @@ if (!empty($data) && is_array($data)) {
                 .replace(/'/g, '&#039;');
         };
 
+        const createPopupHtml = function (record, formattedPrice) {
+            return '<div>' +
+                '<strong>' + escapeHtml(record.Prefecture) + ' ' + escapeHtml(record.Municipality) + '</strong><br>' +
+                '地区: ' + escapeHtml(record.DistrictName || 'N/A') + '<br>' +
+                '価格: ' + escapeHtml(formattedPrice) + '<br>' +
+                '建築年: ' + escapeHtml(record.BuildingYear || 'N/A') + '<br>' +
+                '間取り: ' + escapeHtml(record.FloorPlan || 'N/A') + '<br>' +
+                '建物構造: ' + escapeHtml(record.Structure || 'N/A') + '<br>' +
+                '用途: ' + escapeHtml(record.Purpose || 'N/A') + '<br>' +
+                '時期: ' + escapeHtml(record.Period || 'N/A') +
+                '</div>';
+        };
+
+        const mapAdapter = (function () {
+            if (useGoogleMaps) {
+                const googleMap = new google.maps.Map(document.getElementById('map'), {
+                    center: {lat: defaultCenter[1], lng: defaultCenter[0]},
+                    zoom: defaultZoom,
+                    streetViewControl: true,
+                    mapTypeControl: true,
+                    fullscreenControl: true
+                });
+
+                return {
+                    ready: function (callback) {
+                        callback();
+                    },
+                    addPoint: function (record, coordinates, color, popupHtml) {
+                        const marker = new google.maps.Marker({
+                            map: googleMap,
+                            position: {lat: coordinates[1], lng: coordinates[0]},
+                            icon: {
+                                path: google.maps.SymbolPath.CIRCLE,
+                                scale: 7,
+                                fillColor: color,
+                                fillOpacity: 0.9,
+                                strokeColor: '#1f2937',
+                                strokeWeight: 1
+                            }
+                        });
+                        const infoWindow = new google.maps.InfoWindow({content: popupHtml});
+                        marker.addListener('click', function () {
+                            infoWindow.open({
+                                anchor: marker,
+                                map: googleMap,
+                                shouldFocus: false
+                            });
+                        });
+                    },
+                    fitToBounds: function (plottedCoordinates) {
+                        const bounds = new google.maps.LatLngBounds();
+                        plottedCoordinates.forEach(function (coordinate) {
+                            bounds.extend({lat: coordinate[1], lng: coordinate[0]});
+                        });
+                        googleMap.fitBounds(bounds);
+                    }
+                };
+            }
+
+            const maplibreMap = new maplibregl.Map({
+                container: 'map',
+                style: {
+                    version: 8,
+                    sources: {
+                        osm: {
+                            type: 'raster',
+                            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                            tileSize: 256,
+                            attribution: '&copy; OpenStreetMap contributors'
+                        }
+                    },
+                    layers: [
+                        {
+                            id: 'osm',
+                            type: 'raster',
+                            source: 'osm'
+                        }
+                    ]
+                },
+                center: defaultCenter,
+                zoom: defaultZoom
+            });
+            maplibreMap.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+            return {
+                ready: function (callback) {
+                    maplibreMap.on('load', callback);
+                },
+                addPoint: function (record, coordinates, color, popupHtml) {
+                    new maplibregl.Marker({color: color})
+                        .setLngLat(coordinates)
+                        .setPopup(new maplibregl.Popup({offset: 25}).setHTML(popupHtml))
+                        .addTo(maplibreMap);
+                },
+                fitToBounds: function (plottedCoordinates) {
+                    const bounds = new maplibregl.LngLatBounds();
+                    plottedCoordinates.forEach(function (coordinate) {
+                        bounds.extend(coordinate);
+                    });
+                    maplibreMap.fitBounds(bounds, {
+                        padding: 40,
+                        maxZoom: 13
+                    });
+                }
+            };
+        })();
+
         const renderMapPoints = async function () {
             if (!Array.isArray(records) || records.length === 0) {
                 setMapStatus('表示対象データがありません。', 'warning');
                 return;
             }
 
-            setMapStatus('取引データから地図ポイントを作成中です。', 'secondary');
+            if (useGoogleMaps) {
+                setMapStatus('Google Mapsで表示中です。Pegman を使って Street View を表示できます。', 'info');
+            } else {
+                setMapStatus('MapLibreで表示中です。Google Maps APIキーを設定すると Pegman を利用できます。', 'secondary');
+            }
 
             const geocodeCache = new Map();
             const geocodeLimit = 20;
             let geocodeCount = 0;
             let plottedCount = 0;
-            const bounds = new maplibregl.LngLatBounds();
+            const plottedCoordinates = [];
 
             for (const record of records) {
                 let coordinates = extractCoordinates(record);
@@ -307,26 +399,10 @@ if (!empty($data) && is_array($data)) {
 
                 const price = toPriceNumber(record.TradePrice);
                 const formattedPrice = Number.isFinite(price) ? price.toLocaleString() + ' 円' : 'N/A';
-                const marker = new maplibregl.Marker({color: priceToColor(price)})
-                    .setLngLat(coordinates)
-                    .setPopup(new maplibregl.Popup({offset: 25}).setHTML(
-                        '<div>' +
-                        '<strong>' + escapeHtml(record.Prefecture) + ' ' + escapeHtml(record.Municipality) + '</strong><br>' +
-                        '地区: ' + escapeHtml(record.DistrictName || 'N/A') + '<br>' +
-                        '価格: ' + escapeHtml(formattedPrice) + '<br>' +
-                        '建築年: ' + escapeHtml(record.BuildingYear || 'N/A') + '<br>' +
-                        '間取り: ' + escapeHtml(record.FloorPlan || 'N/A') + '<br>' +
-                        '建物構造: ' + escapeHtml(record.Structure || 'N/A') + '<br>' +
-                        '用途: ' + escapeHtml(record.Purpose || 'N/A') + '<br>' +
-                        '時期: ' + escapeHtml(record.Period || 'N/A') +
-                        '</div>'
-                    ))
-                    .addTo(map);
-
-                if (marker) {
-                    plottedCount += 1;
-                    bounds.extend(coordinates);
-                }
+                const popupHtml = createPopupHtml(record, formattedPrice);
+                mapAdapter.addPoint(record, coordinates, priceToColor(price), popupHtml);
+                plottedCount += 1;
+                plottedCoordinates.push(coordinates);
             }
 
             if (plottedCount === 0) {
@@ -334,14 +410,15 @@ if (!empty($data) && is_array($data)) {
                 return;
             }
 
-            map.fitBounds(bounds, {
-                padding: 40,
-                maxZoom: 13
-            });
-            setMapStatus('地図に ' + plottedCount + ' 件の取引データを表示しました。', 'success');
+            mapAdapter.fitToBounds(plottedCoordinates);
+            if (useGoogleMaps) {
+                setMapStatus('Google Mapsに ' + plottedCount + ' 件を表示しました。PegmanでStreet View表示が可能です。', 'success');
+            } else {
+                setMapStatus('MapLibreに ' + plottedCount + ' 件を表示しました。', 'success');
+            }
         };
 
-        map.on('load', function () {
+        mapAdapter.ready(function () {
             renderMapPoints().catch(function () {
                 setMapStatus('地図データの表示中にエラーが発生しました。', 'danger');
             });

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -9,6 +9,9 @@
 <body>
 <div class="container mt-5">
     <h1 class="mb-4 text-center">条件選択画面</h1>
+    <div class="mb-3 text-right">
+        <?= $this->Html->link('API探索（別機能）', ['controller' => 'API', 'action' => 'apiExplorer'], ['class' => 'btn btn-outline-info']) ?>
+    </div>
     <?= $this->Form->create(null, ['url' => ['action' => 'selectAPI'], 'class' => 'needs-validation', 'novalidate' => true]) ?>
     <div class="form-group">
         <?= $this->Form->control('prefecture', [


### PR DESCRIPTION
## 概要\n不動産情報ライブラリAPI活用の基盤機能を段階的に実装しました。\n\n## 変更内容\n- MapLibre導入と地図初期表示\n- 取引価格データの地図可視化（価格色分け、ポップアップ）\n- 建物情報（建築年/間取り/構造/用途）の表示\n- Google Maps Street View(Pegman)のオプション対応\n- XPT001ポイントAPIの統合（座標を優先利用）\n- 別機能として API Explorer 画面を追加\n  - 全APIカタログ表示\n  - API実行URL/cURL/JSON結果の確認\n- カテゴリー別モード切替基盤（生活/防災/投資）とレイヤー表示ON/OFF\n\n## 関連Issue\n- #3\n- #7\n- #8\n- #9\n- #10\n- #11\n- #12\n\n## 備考\n- 既存環境の依存関係事情により、プロジェクト全体テスト実行は制約あり（変更ファイルの構文確認は実施済み）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added interactive map visualization to display property data with multiple layer modes (shopping/living, safety/disaster, professional/investment) and building details.
- Introduced an API explorer tool for developers to test endpoints with generated request examples and response previews.
- Enhanced property listings with building information and coordinate mapping capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->