### PR TITLE
feat: GeoJSONプロキシで地図マッピングを強化

### DIFF
--- a/html/product_thing/config/bootstrap.php
+++ b/html/product_thing/config/bootstrap.php
@@ -78,8 +78,8 @@ use Cake\Utility\Security;
  * that changes from configuration that does not. This makes deployment simpler.
  */
 
-$dotenv  = \Dotenv\Dotenv::createImmutable(__DIR__ . '/../../..');
-$dotenv->load();
+$dotenv = \Dotenv\Dotenv::createImmutable(dirname(__DIR__, 2));
+$dotenv->safeLoad();
 try {
     Configure::config('default', new PhpConfig());
     Configure::load('app', 'default', false);

--- a/html/product_thing/config/bootstrap.php
+++ b/html/product_thing/config/bootstrap.php
@@ -78,8 +78,17 @@ use Cake\Utility\Security;
  * that changes from configuration that does not. This makes deployment simpler.
  */
 
-$dotenv = \Dotenv\Dotenv::createImmutable(dirname(__DIR__, 2));
-$dotenv->safeLoad();
+$dotenvCandidates = [
+    dirname(__DIR__),
+    dirname(__DIR__, 2),
+    dirname(__DIR__, 3),
+];
+foreach ($dotenvCandidates as $dotenvDir) {
+    if (file_exists($dotenvDir . DS . '.env')) {
+        \Dotenv\Dotenv::createImmutable($dotenvDir)->safeLoad();
+        break;
+    }
+}
 try {
     Configure::config('default', new PhpConfig());
     Configure::load('app', 'default', false);

--- a/html/product_thing/config/routes.php
+++ b/html/product_thing/config/routes.php
@@ -58,14 +58,12 @@ return function (RouteBuilder $routes): void {
          * to use (in this case, templates/Pages/home.php)...
          */
 
-        $builder->connect('/', ['controller' => 'API', 'action' => 'index']);
+        $builder->connect('/', ['controller' => 'PriceSearch', 'action' => 'index']);
         $builder->connect('/api/mlit/transactions', ['controller' => 'MlitProxy', 'action' => 'transactions']);
         $builder->connect('/api/mlit/geojson', ['controller' => 'MlitProxy', 'action' => 'geojson']);
-        $builder->connect('/API', ['controller' => 'API', 'action' => 'r_EstateAPI']);
-        $builder->connect('/API/select_a_p_i', ['controller' => 'API', 'action' => 'selectAPI']);
         $builder->connect(
             '/api/displayPrice/**',
-            ['controller' => 'API', 'action' => 'displayPrice'],
+            ['controller' => 'PriceSearch', 'action' => 'displayPrice'],
             [
                 'pass' => ['','cityID', 'year', 'quarter'], // ここで指定したパラメータがアクションメソッドに渡される
                 'cityID' => '[0-9]+', // cityIDは数字のみ
@@ -74,14 +72,13 @@ return function (RouteBuilder $routes): void {
             ]
         );
 
-            $builder->connect('/API/displayPrice/:prefectureCode/:cityID/:year', ['controller' => 'API', 'action' => 'displayPrice'], ['pass' => ['prefectureCode', 'cityID', 'year']]);
+            $builder->connect('/API/displayPrice/:prefectureCode/:cityID/:year', ['controller' => 'PriceSearch', 'action' => 'displayPrice'], ['pass' => ['prefectureCode', 'cityID', 'year']]);
 
         /*
          * ...and connect the rest of 'Pages' controller's URLs.
          */
         $builder->connect('/pages/*', 'Pages::display');
-        $builder->connect('/API', 'API::r_EstateAPI');
-        $builder->connect('/API/display_price', 'API::displayPrice');
+        $builder->connect('/API/display_price', 'PriceSearch::displayPrice');
 
 
 

--- a/html/product_thing/config/routes.php
+++ b/html/product_thing/config/routes.php
@@ -59,6 +59,24 @@ return function (RouteBuilder $routes): void {
          */
 
         $builder->connect('/', ['controller' => 'PriceSearch', 'action' => 'index']);
+
+        // PriceSearch URLs
+        $builder->connect('/price-search/select', ['controller' => 'PriceSearch', 'action' => 'selectAPI']);
+        $builder->connect('/price-search/display', ['controller' => 'PriceSearch', 'action' => 'displayPrice']);
+        // Legacy URLs
+        $builder->connect('/API/select_a_p_i', ['controller' => 'PriceSearch', 'action' => 'selectAPI']);
+        $builder->connect('/API/display_price', ['controller' => 'PriceSearch', 'action' => 'displayPrice']);
+        $builder->connect('/API/displayPrice/:prefectureCode/:cityID/:year', ['controller' => 'PriceSearch', 'action' => 'displayPrice'], ['pass' => ['prefectureCode', 'cityID', 'year']]);
+
+        // Explorer URLs
+        $builder->connect('/api-explorer', ['controller' => 'ApiExplorer', 'action' => 'apiExplorer']);
+        $builder->connect('/API/api-explorer', ['controller' => 'ApiExplorer', 'action' => 'apiExplorer']);
+
+        // LayerData URLs
+        $builder->connect('/layer-data', ['controller' => 'LayerData', 'action' => 'layerData']);
+        $builder->connect('/api/layer-data', ['controller' => 'LayerData', 'action' => 'layerData']);
+
+        // MLIT proxy URLs
         $builder->connect('/api/mlit/transactions', ['controller' => 'MlitProxy', 'action' => 'transactions']);
         $builder->connect('/api/mlit/geojson', ['controller' => 'MlitProxy', 'action' => 'geojson']);
         $builder->connect(
@@ -71,14 +89,10 @@ return function (RouteBuilder $routes): void {
                 'quarter' => '[1-4]' // 四半期は1から4の数字
             ]
         );
-
-            $builder->connect('/API/displayPrice/:prefectureCode/:cityID/:year', ['controller' => 'PriceSearch', 'action' => 'displayPrice'], ['pass' => ['prefectureCode', 'cityID', 'year']]);
-
         /*
          * ...and connect the rest of 'Pages' controller's URLs.
          */
         $builder->connect('/pages/*', 'Pages::display');
-        $builder->connect('/API/display_price', 'PriceSearch::displayPrice');
 
 
 

--- a/html/product_thing/config/routes.php
+++ b/html/product_thing/config/routes.php
@@ -60,6 +60,7 @@ return function (RouteBuilder $routes): void {
 
         $builder->connect('/', ['controller' => 'API', 'action' => 'index']);
         $builder->connect('/api/mlit/transactions', ['controller' => 'MlitProxy', 'action' => 'transactions']);
+        $builder->connect('/api/mlit/geojson', ['controller' => 'MlitProxy', 'action' => 'geojson']);
         $builder->connect('/API', ['controller' => 'API', 'action' => 'r_EstateAPI']);
         $builder->connect('/API/select_a_p_i', ['controller' => 'API', 'action' => 'selectAPI']);
         $builder->connect(

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -89,9 +89,8 @@ class APIController extends AppController
 
         $base_url = 'https://www.reinfolib.mlit.go.jp/ex-api/external/XIT002?';
         $baseurl2 = 'https://www.reinfolib.mlit.go.jp/ex-api/external/XIT001?';
-        $query  = [
+        $query = [
             'area' => $prefectureCode,
-            'year' => $year,
         ];
 
         $header = array(

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -387,6 +387,8 @@ class APIController extends AppController
 
         $apiId = (string)$this->request->getQuery('api_id');
         $allowedApiIds = [
+            'XKT010', // 医療機関
+            'XKT029', // 土砂災害警戒区域
             'XKT019',
         ];
         if (!in_array($apiId, $allowedApiIds, true)) {

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -89,12 +89,11 @@ class APIController extends AppController
 
         $base_url = 'https://www.reinfolib.mlit.go.jp/ex-api/external/XIT002?';
         $baseurl2 = 'https://www.reinfolib.mlit.go.jp/ex-api/external/XIT001?';
+        $cityListYear = !empty($year) ? (string)$year : '2024';
         $query = [
             'area' => $prefectureCode,
+            'year' => $cityListYear,
         ];
-        if (!empty($year)) {
-            $query['year'] = $year;
-        }
 
         $header = array(
             'Content-Type: application/x-www-form-urlencoded',

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -92,6 +92,9 @@ class APIController extends AppController
         $query = [
             'area' => $prefectureCode,
         ];
+        if (!empty($year)) {
+            $query['year'] = $year;
+        }
 
         $header = array(
             'Content-Type: application/x-www-form-urlencoded',

--- a/html/product_thing/src/Controller/APIController.php
+++ b/html/product_thing/src/Controller/APIController.php
@@ -55,6 +55,9 @@ class APIController extends AppController
 
     public function selectAPI($prefectureCode = null,$cityID = null,$year = null)
     {
+        $prefectureCode = (string)$this->request->getQuery('prefecture', $prefectureCode ?? '');
+        $year = (string)$this->request->getQuery('year', $year ?? '');
+
         //データベースから選択できるようにしたい
         if ($this->request->is('post')) {
             $prefectureCode = $this->request->getData('prefecture');
@@ -111,13 +114,20 @@ class APIController extends AppController
 
         $context = stream_context_create($content);
 
-        $response = file_get_contents(
-            $base_url.http_build_query($query),false,$context);
+        $response = false;
+        if (!empty($prefectureCode)) {
+            $response = file_get_contents(
+                $base_url . http_build_query($query), false, $context
+            );
+        }
 
-        if(substr($response,0,2) === "\x1f\x8b"){
-            $decode_response = json_decode(gzdecode($response),true);
-        }else{
-            $decode_response = json_decode($response,true);
+        $decode_response = [];
+        if (is_string($response) && $response !== '') {
+            if (substr($response,0,2) === "\x1f\x8b") {
+                $decode_response = json_decode(gzdecode($response),true);
+            } else {
+                $decode_response = json_decode($response,true);
+            }
         }
 
         $this->set('prefectures', $this->getPrefectures());
@@ -133,9 +143,9 @@ class APIController extends AppController
             error_log('APIからのデータ取得に失敗しました。');
         }
 
-        //年度をgetYearメソッドから取得
-        $year = $this->getYear();
-        $this->set('years', $year);
+        $this->set('years', $this->getYear());
+        $this->set('selectedPrefecture', $prefectureCode);
+        $this->set('selectedYear', $year);
 
     }
 

--- a/html/product_thing/src/Controller/ApiExplorerController.php
+++ b/html/product_thing/src/Controller/ApiExplorerController.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+class ApiExplorerController extends APIController
+{
+    public function apiExplorer()
+    {
+        return parent::apiExplorer();
+    }
+}

--- a/html/product_thing/src/Controller/ApiExplorerController.php
+++ b/html/product_thing/src/Controller/ApiExplorerController.php
@@ -5,6 +5,12 @@ namespace App\Controller;
 
 class ApiExplorerController extends APIController
 {
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->viewBuilder()->setTemplatePath('API');
+    }
+
     public function apiExplorer()
     {
         return parent::apiExplorer();

--- a/html/product_thing/src/Controller/LayerDataController.php
+++ b/html/product_thing/src/Controller/LayerDataController.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+class LayerDataController extends APIController
+{
+    public function layerData()
+    {
+        return parent::layerData();
+    }
+}

--- a/html/product_thing/src/Controller/MlitProxyController.php
+++ b/html/product_thing/src/Controller/MlitProxyController.php
@@ -6,10 +6,12 @@ namespace App\Controller;
 use Cake\Http\Client;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
+use RuntimeException;
 
 class MlitProxyController extends AppController
 {
-    private const MLIT_PATH = '/ex-api/external/XIT001';
+    private const TRANSACTIONS_PATH = '/ex-api/external/XIT001';
+    private const TRANSACTION_POINTS_PATH = '/ex-api/external/XPT001';
 
     private const ALLOWED_QUERY_PARAMS = [
         'year',
@@ -23,35 +25,33 @@ class MlitProxyController extends AppController
     public function transactions()
     {
         $this->request->allowMethod(['get']);
-
-        $apiKey = (string)env('MLIT_API_KEY', (string)env('API_KEY', ''));
-        if ($apiKey === '') {
-            throw new InternalErrorException('MLIT API key is not configured.');
-        }
-
-        $query = $this->buildQueryParams();
-        if ($query === []) {
-            throw new BadRequestException('At least one query parameter is required.');
-        }
-
-        $client = new Client([
-            'scheme' => 'https',
-            'host' => 'www.reinfolib.mlit.go.jp',
-            'timeout' => 15,
+        $query = $this->requireQueryParams();
+        $apiResponse = $this->createApiClient()->get(self::TRANSACTIONS_PATH, $query, [
+            'headers' => $this->buildHeaders($this->requireApiKey()),
         ]);
 
-        $apiResponse = $client->get(self::MLIT_PATH, $query, [
-            'headers' => [
-                'Accept' => 'application/json',
-                'Accept-Encoding' => 'identity',
-                'Ocp-Apim-Subscription-Key' => $apiKey,
-            ],
-        ]);
+        return $this->jsonResponse($apiResponse->getStringBody(), $apiResponse->getStatusCode());
+    }
 
-        return $this->response
-            ->withType('application/json')
-            ->withStatus($apiResponse->getStatusCode())
-            ->withStringBody($apiResponse->getStringBody());
+    public function geojson()
+    {
+        $this->request->allowMethod(['get']);
+        $query = $this->requireQueryParams();
+        $apiKey = $this->requireApiKey();
+        $client = $this->createApiClient();
+        $headers = $this->buildHeaders($apiKey);
+
+        $transactions = $client->get(self::TRANSACTIONS_PATH, $query, ['headers' => $headers]);
+        $points = $client->get(self::TRANSACTION_POINTS_PATH, $query, ['headers' => $headers]);
+
+        $transactionData = $this->extractDataRows($transactions->getStringBody());
+        $pointData = $this->extractDataRows($points->getStringBody());
+        $featureCollection = [
+            'type' => 'FeatureCollection',
+            'features' => $this->buildFeatures($transactionData, $pointData),
+        ];
+
+        return $this->jsonResponse(json_encode($featureCollection, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
     }
 
     /**
@@ -69,5 +69,133 @@ class MlitProxyController extends AppController
         }
 
         return $query;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function requireQueryParams(): array
+    {
+        $query = $this->buildQueryParams();
+        if ($query === []) {
+            throw new BadRequestException('At least one query parameter is required.');
+        }
+
+        return $query;
+    }
+
+    private function requireApiKey(): string
+    {
+        $apiKey = (string)env('MLIT_API_KEY', (string)env('API_KEY', ''));
+        if ($apiKey === '') {
+            throw new InternalErrorException('MLIT API key is not configured.');
+        }
+
+        return $apiKey;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildHeaders(string $apiKey): array
+    {
+        return [
+            'Accept' => 'application/json',
+            'Accept-Encoding' => 'identity',
+            'Ocp-Apim-Subscription-Key' => $apiKey,
+        ];
+    }
+
+    private function createApiClient(): Client
+    {
+        return new Client([
+            'scheme' => 'https',
+            'host' => 'www.reinfolib.mlit.go.jp',
+            'timeout' => 15,
+        ]);
+    }
+
+    private function jsonResponse(string $body, int $status = 200)
+    {
+        return $this->response
+            ->withType('application/json')
+            ->withStatus($status)
+            ->withStringBody($body);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function extractDataRows(string $responseBody): array
+    {
+        $decoded = json_decode($responseBody, true);
+        if (!is_array($decoded) || !isset($decoded['data']) || !is_array($decoded['data'])) {
+            throw new RuntimeException('Invalid MLIT API response format.');
+        }
+
+        return array_values(array_filter($decoded['data'], 'is_array'));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $transactions
+     * @param array<int, array<string, mixed>> $points
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildFeatures(array $transactions, array $points): array
+    {
+        $features = [];
+        foreach ($transactions as $index => $row) {
+            if (!isset($points[$index]) || !is_array($points[$index])) {
+                continue;
+            }
+
+            $coordinates = $this->extractCoordinates($points[$index]);
+            if ($coordinates === null) {
+                continue;
+            }
+
+            $features[] = [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'Point',
+                    'coordinates' => $coordinates,
+                ],
+                'properties' => $row,
+            ];
+        }
+
+        return $features;
+    }
+
+    /**
+     * @return array<int, float>|null
+     */
+    private function extractCoordinates(array $row): ?array
+    {
+        $longitude = $this->extractCoordinateValue($row, ['Longitude', 'longitude', 'lng', 'Lon', 'LON', 'x']);
+        $latitude = $this->extractCoordinateValue($row, ['Latitude', 'latitude', 'lat', 'Lat', 'LAT', 'y']);
+        if ($longitude === null || $latitude === null) {
+            return null;
+        }
+
+        return [$longitude, $latitude];
+    }
+
+    /**
+     * @param array<int, string> $keys
+     */
+    private function extractCoordinateValue(array $row, array $keys): ?float
+    {
+        foreach ($keys as $key) {
+            if (!isset($row[$key]) || $row[$key] === '') {
+                continue;
+            }
+            $value = (float)$row[$key];
+            if (is_finite($value)) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 }

--- a/html/product_thing/src/Controller/MlitProxyController.php
+++ b/html/product_thing/src/Controller/MlitProxyController.php
@@ -6,7 +6,6 @@ namespace App\Controller;
 use Cake\Http\Client;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
-use RuntimeException;
 
 class MlitProxyController extends AppController
 {
@@ -43,6 +42,16 @@ class MlitProxyController extends AppController
 
         $transactions = $client->get(self::TRANSACTIONS_PATH, $query, ['headers' => $headers]);
         $points = $client->get(self::TRANSACTION_POINTS_PATH, $query, ['headers' => $headers]);
+        if ($transactions->getStatusCode() >= 400 || $points->getStatusCode() >= 400) {
+            return $this->jsonResponse(
+                json_encode([
+                    'type' => 'FeatureCollection',
+                    'features' => [],
+                    'error' => 'Failed to fetch MLIT source data.',
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                502
+            );
+        }
 
         $transactionData = $this->extractDataRows($transactions->getStringBody());
         $pointData = $this->extractDataRows($points->getStringBody());
@@ -128,12 +137,29 @@ class MlitProxyController extends AppController
      */
     private function extractDataRows(string $responseBody): array
     {
-        $decoded = json_decode($responseBody, true);
+        $decoded = $this->decodeJsonBody($responseBody);
         if (!is_array($decoded) || !isset($decoded['data']) || !is_array($decoded['data'])) {
-            throw new RuntimeException('Invalid MLIT API response format.');
+            return [];
         }
 
         return array_values(array_filter($decoded['data'], 'is_array'));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeJsonBody(string $body): ?array
+    {
+        $decodedBody = $body;
+        if (substr($body, 0, 2) === "\x1f\x8b") {
+            $inflated = gzdecode($body);
+            if ($inflated !== false) {
+                $decodedBody = $inflated;
+            }
+        }
+
+        $json = json_decode($decodedBody, true);
+        return is_array($json) ? $json : null;
     }
 
     /**

--- a/html/product_thing/src/Controller/PriceSearchController.php
+++ b/html/product_thing/src/Controller/PriceSearchController.php
@@ -5,6 +5,12 @@ namespace App\Controller;
 
 class PriceSearchController extends APIController
 {
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->viewBuilder()->setTemplatePath('API');
+    }
+
     public function index()
     {
         return $this->selectAPI();

--- a/html/product_thing/src/Controller/PriceSearchController.php
+++ b/html/product_thing/src/Controller/PriceSearchController.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+class PriceSearchController extends APIController
+{
+    public function index()
+    {
+        return $this->selectAPI();
+    }
+
+    public function selectAPI($prefectureCode = null, $cityID = null, $year = null)
+    {
+        return parent::selectAPI($prefectureCode, $cityID, $year);
+    }
+
+    public function displayPrice($prefectureCode = null, $cityID = null, $year = null)
+    {
+        return parent::displayPrice($prefectureCode, $cityID, $year);
+    }
+}

--- a/html/product_thing/templates/API/api_explorer.php
+++ b/html/product_thing/templates/API/api_explorer.php
@@ -12,7 +12,7 @@
     <p class="text-muted">デベロッパー向けに、全API IDを選んで実行URL・cURL・JSONレスポンスを確認できます。</p>
 
     <div class="mb-3">
-        <?= $this->Html->link('価格情報画面に戻る', ['controller' => 'PriceSearch', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary']) ?>
+        <?= $this->Html->link('価格情報画面に戻る', '/price-search/select', ['class' => 'btn btn-outline-secondary']) ?>
     </div>
 
     <?php if (!empty($errorMessage)): ?>

--- a/html/product_thing/templates/API/api_explorer.php
+++ b/html/product_thing/templates/API/api_explorer.php
@@ -12,7 +12,7 @@
     <p class="text-muted">デベロッパー向けに、全API IDを選んで実行URL・cURL・JSONレスポンスを確認できます。</p>
 
     <div class="mb-3">
-        <?= $this->Html->link('価格情報画面に戻る', ['controller' => 'API', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary']) ?>
+        <?= $this->Html->link('価格情報画面に戻る', ['controller' => 'PriceSearch', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary']) ?>
     </div>
 
     <?php if (!empty($errorMessage)): ?>

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -170,7 +170,7 @@ if (!empty($data) && is_array($data)) {
         const defaultZoom = 10;
         const googleMapsApiKey = <?= json_encode($googleMapsApiKey ?? null, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const useGoogleMaps = Boolean(googleMapsApiKey && window.google && window.google.maps);
-        const layerDataEndpoint = <?= json_encode($this->Url->build(['controller' => 'LayerData', 'action' => 'layerData'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        const layerDataEndpoint = <?= json_encode('/layer-data', JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const geoJsonEndpoint = <?= json_encode($this->Url->build(['controller' => 'MlitProxy', 'action' => 'geojson'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const mapStatus = document.getElementById('mapStatus');
         let records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -187,14 +187,19 @@ if (!empty($data) && is_array($data)) {
             {id: 'price-points', label: '取引価格ポイント', available: true},
             {id: 'medical-facilities', label: '医療機関（XKT010）', available: true},
             {id: 'facility-poi', label: '生活施設レイヤー（準備中）', available: false},
-            {id: 'hazard-zones', label: '防災リスクレイヤー（準備中）', available: false},
+            {id: 'hazard-zones', label: '土砂災害警戒区域（XKT029）', available: true},
             {id: 'urban-plan', label: '都市計画レイヤー（準備中）', available: false},
             {id: 'population-heat', label: '人口ヒートマップ（準備中）', available: false},
             {id: 'nature-parks', label: '自然公園地域（XKT019）', available: true}
         ];
+        const layerApiConfigs = {
+            'medical-facilities': {apiId: 'XKT010', color: '#dc2626', title: '医療機関'},
+            'hazard-zones': {apiId: 'XKT029', color: '#f59e0b', title: '土砂災害警戒区域'},
+            'nature-parks': {apiId: 'XKT019', color: '#15803d', title: '自然公園地域'}
+        };
         const modeDefaults = {
             living: ['price-points', 'medical-facilities', 'facility-poi'],
-            safety: ['price-points', 'hazard-zones'],
+            safety: ['price-points', 'hazard-zones', 'medical-facilities'],
             invest: ['price-points', 'urban-plan', 'population-heat'],
             nature: ['price-points', 'nature-parks']
         };
@@ -202,6 +207,8 @@ if (!empty($data) && is_array($data)) {
         const activeLayers = new Set(modeDefaults[currentMode]);
         const layerMarkerRegistry = {
             'price-points': [],
+            'medical-facilities': [],
+            'hazard-zones': [],
             'nature-parks': []
         };
 
@@ -247,10 +254,11 @@ if (!empty($data) && is_array($data)) {
                         activeLayers.add(targetLayerId);
                     } else {
                         activeLayers.delete(targetLayerId);
+                        clearLayerMarkers(targetLayerId);
                     }
                     applyLayerVisibility();
-                    if (targetLayerId === 'nature-parks' && checkbox.checked) {
-                        loadNatureParksLayer();
+                    if (checkbox.checked) {
+                        loadApiLayer(targetLayerId);
                     }
                 });
             });
@@ -376,13 +384,13 @@ if (!empty($data) && is_array($data)) {
                 '</div>';
         };
 
-        const createNaturePopupHtml = function (record) {
+        const createLayerPopupHtml = function (record, title) {
             const keys = Object.keys(record || {}).slice(0, 6);
             if (keys.length === 0) {
-                return '<div><strong>自然公園地域</strong><br>属性情報なし</div>';
+                return '<div><strong>' + escapeHtml(title) + '</strong><br>属性情報なし</div>';
             }
 
-            let body = '<div><strong>自然公園地域（XKT019）</strong><br>';
+            let body = '<div><strong>' + escapeHtml(title) + '</strong><br>';
             keys.forEach(function (key) {
                 body += escapeHtml(key) + ': ' + escapeHtml(record[key]) + '<br>';
             });
@@ -540,17 +548,16 @@ if (!empty($data) && is_array($data)) {
             layerMarkerRegistry[layerId] = [];
         };
 
-        const loadNatureParksLayer = async function () {
-            if (currentMode !== 'nature' || !activeLayers.has('nature-parks')) {
+        const loadApiLayer = async function (layerId) {
+            const config = layerApiConfigs[layerId];
+            if (!config || !activeLayers.has(layerId)) {
                 return;
             }
-            if (layerMarkerRegistry['nature-parks'].length > 0) {
-                return;
-            }
+            clearLayerMarkers(layerId);
 
             const center = mapAdapter.getCenter();
             const params = new URLSearchParams({
-                api_id: 'XKT019',
+                api_id: config.apiId,
                 lat: String(center[1]),
                 lon: String(center[0]),
                 radius: '3000'
@@ -574,14 +581,23 @@ if (!empty($data) && is_array($data)) {
                 if (!coordinates) {
                     return;
                 }
-                const marker = mapAdapter.addPoint(row, coordinates, '#15803d', createNaturePopupHtml(row));
-                layerMarkerRegistry['nature-parks'].push(marker);
+                const marker = mapAdapter.addPoint(row, coordinates, config.color, createLayerPopupHtml(row, config.title + '（' + config.apiId + '）'));
+                layerMarkerRegistry[layerId].push(marker);
                 plotted += 1;
             });
+
             if (plotted > 0) {
                 applyLayerVisibility();
-                setMapStatus('自然環境モードで自然公園地域レイヤーを ' + plotted + ' 件表示しました。', 'info');
+                setMapStatus(modeName[currentMode] + 'モードで ' + config.title + ' レイヤーを ' + plotted + ' 件表示しました。', 'info');
             }
+        };
+
+        const reloadActiveApiLayers = function () {
+            Object.keys(layerApiConfigs).forEach(function (layerId) {
+                if (activeLayers.has(layerId)) {
+                    loadApiLayer(layerId);
+                }
+            });
         };
 
         const fetchGeoJsonRecords = async function () {
@@ -675,9 +691,7 @@ if (!empty($data) && is_array($data)) {
             applyLayerVisibility();
             const mapText = useGoogleMaps ? 'Google Maps（Street View利用可）' : 'MapLibre';
             setMapStatus(modeName[currentMode] + 'モードで ' + plottedCount + ' 件を表示中です（' + mapText + '）。', 'success');
-            if (currentMode === 'nature') {
-                loadNatureParksLayer();
-            }
+            reloadActiveApiLayers();
         };
 
         modeButtons.forEach(function (button) {
@@ -691,9 +705,7 @@ if (!empty($data) && is_array($data)) {
                 renderLayerControls();
                 applyLayerVisibility();
                 setMapStatus(modeName[currentMode] + 'モードに切り替えました。', 'info');
-                if (currentMode === 'nature') {
-                    loadNatureParksLayer();
-                }
+                reloadActiveApiLayers();
             });
         });
 
@@ -718,10 +730,13 @@ if (!empty($data) && is_array($data)) {
                 moveRefreshTimer = setTimeout(function () {
                     fetchGeoJsonRecords().then(function (nextRecords) {
                         if (!Array.isArray(nextRecords) || nextRecords.length === 0) {
+                            reloadActiveApiLayers();
                             return;
                         }
                         records = nextRecords;
-                        return renderMapPoints(false);
+                        return renderMapPoints(false).then(function () {
+                            reloadActiveApiLayers();
+                        });
                     }).catch(function () {
                         setMapStatus('地図移動後の再取得に失敗しました。', 'warning');
                     });

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -171,8 +171,10 @@ if (!empty($data) && is_array($data)) {
         const googleMapsApiKey = <?= json_encode($googleMapsApiKey ?? null, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const useGoogleMaps = Boolean(googleMapsApiKey && window.google && window.google.maps);
         const layerDataEndpoint = <?= json_encode($this->Url->build(['controller' => 'API', 'action' => 'layerData'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        const geoJsonEndpoint = <?= json_encode($this->Url->build(['controller' => 'MlitProxy', 'action' => 'geojson'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const mapStatus = document.getElementById('mapStatus');
-        const records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        let records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        const pageQuery = new URLSearchParams(window.location.search);
         const layerControls = document.getElementById('layerControls');
         const modeButtons = document.querySelectorAll('.mode-btn');
         const modeName = {
@@ -261,6 +263,13 @@ if (!empty($data) && is_array($data)) {
         };
 
         const extractCoordinates = function (record) {
+            if (record && record.geometry && Array.isArray(record.geometry.coordinates) && record.geometry.coordinates.length === 2) {
+                const featureLng = Number(record.geometry.coordinates[0]);
+                const featureLat = Number(record.geometry.coordinates[1]);
+                if (Number.isFinite(featureLng) && Number.isFinite(featureLat)) {
+                    return [featureLng, featureLat];
+                }
+            }
             const pairs = [
                 ['Longitude', 'Latitude'],
                 ['longitude', 'latitude'],
@@ -277,6 +286,14 @@ if (!empty($data) && is_array($data)) {
             }
 
             return null;
+        };
+
+        const toRecordProperties = function (record) {
+            if (record && record.properties && typeof record.properties === 'object') {
+                return record.properties;
+            }
+
+            return record;
         };
 
         const buildAddress = function (record) {
@@ -391,6 +408,18 @@ if (!empty($data) && is_array($data)) {
                         const center = googleMap.getCenter();
                         return [center.lng(), center.lat()];
                     },
+                    getBounds: function () {
+                        const bounds = googleMap.getBounds();
+                        if (!bounds) {
+                            return null;
+                        }
+                        const sw = bounds.getSouthWest();
+                        const ne = bounds.getNorthEast();
+                        return [sw.lng(), sw.lat(), ne.lng(), ne.lat()];
+                    },
+                    onMoveEnd: function (callback) {
+                        googleMap.addListener('idle', callback);
+                    },
                     addPoint: function (record, coordinates, color, popupHtml) {
                         const marker = new google.maps.Marker({
                             map: googleMap,
@@ -463,6 +492,16 @@ if (!empty($data) && is_array($data)) {
                 getCenter: function () {
                     const center = maplibreMap.getCenter();
                     return [center.lng, center.lat];
+                },
+                getBounds: function () {
+                    const bounds = maplibreMap.getBounds();
+                    if (!bounds) {
+                        return null;
+                    }
+                    return [bounds.getWest(), bounds.getSouth(), bounds.getEast(), bounds.getNorth()];
+                },
+                onMoveEnd: function (callback) {
+                    maplibreMap.on('moveend', callback);
                 },
                 addPoint: function (record, coordinates, color, popupHtml) {
                     const marker = new maplibregl.Marker({color: color})
@@ -545,11 +584,48 @@ if (!empty($data) && is_array($data)) {
             }
         };
 
-        const renderMapPoints = async function () {
+        const fetchGeoJsonRecords = async function () {
+            const requiredParams = ['area', 'city', 'year'];
+            const hasRequiredParams = requiredParams.every(function (param) {
+                const value = pageQuery.get(param);
+                return typeof value === 'string' && value !== '';
+            });
+            if (!hasRequiredParams) {
+                return null;
+            }
+
+            const params = new URLSearchParams({
+                area: pageQuery.get('area'),
+                city: pageQuery.get('city'),
+                year: pageQuery.get('year')
+            });
+            const bounds = mapAdapter.getBounds();
+            if (Array.isArray(bounds) && bounds.length === 4) {
+                params.set('bbox', bounds.join(','));
+            }
+
+            const response = await fetch(geoJsonEndpoint + '?' + params.toString(), {
+                headers: {
+                    'Accept': 'application/json'
+                }
+            });
+            if (!response.ok) {
+                return null;
+            }
+            const payload = await response.json();
+            if (!payload || payload.type !== 'FeatureCollection' || !Array.isArray(payload.features)) {
+                return null;
+            }
+
+            return payload.features;
+        };
+
+        const renderMapPoints = async function (fitBounds = true) {
             if (!Array.isArray(records) || records.length === 0) {
                 setMapStatus('表示対象データがありません。', 'warning');
                 return;
             }
+            clearLayerMarkers('price-points');
 
             setMapStatus(modeName[currentMode] + 'モードでレイヤーを準備中です。', 'secondary');
 
@@ -561,8 +637,9 @@ if (!empty($data) && is_array($data)) {
 
             for (const record of records) {
                 let coordinates = extractCoordinates(record);
+                const properties = toRecordProperties(record);
                 if (!coordinates && geocodeCount < geocodeLimit) {
-                    const address = buildAddress(record);
+                    const address = buildAddress(properties);
                     if (address) {
                         if (geocodeCache.has(address)) {
                             coordinates = geocodeCache.get(address);
@@ -578,10 +655,10 @@ if (!empty($data) && is_array($data)) {
                     continue;
                 }
 
-                const price = toPriceNumber(record.TradePrice);
+                const price = toPriceNumber(properties.TradePrice);
                 const formattedPrice = Number.isFinite(price) ? price.toLocaleString() + ' 円' : 'N/A';
-                const popupHtml = createPopupHtml(record, formattedPrice);
-                const markerWrapper = mapAdapter.addPoint(record, coordinates, priceToColor(price), popupHtml);
+                const popupHtml = createPopupHtml(properties, formattedPrice);
+                const markerWrapper = mapAdapter.addPoint(properties, coordinates, priceToColor(price), popupHtml);
                 layerMarkerRegistry['price-points'].push(markerWrapper);
                 plottedCount += 1;
                 plottedCoordinates.push(coordinates);
@@ -592,7 +669,9 @@ if (!empty($data) && is_array($data)) {
                 return;
             }
 
-            mapAdapter.fitToBounds(plottedCoordinates);
+            if (fitBounds) {
+                mapAdapter.fitToBounds(plottedCoordinates);
+            }
             applyLayerVisibility();
             const mapText = useGoogleMaps ? 'Google Maps（Street View利用可）' : 'MapLibre';
             setMapStatus(modeName[currentMode] + 'モードで ' + plottedCount + ' 件を表示中です（' + mapText + '）。', 'success');
@@ -622,8 +701,31 @@ if (!empty($data) && is_array($data)) {
         renderLayerControls();
 
         mapAdapter.ready(function () {
-            renderMapPoints().catch(function () {
+            fetchGeoJsonRecords().then(function (initialRecords) {
+                if (Array.isArray(initialRecords) && initialRecords.length > 0) {
+                    records = initialRecords;
+                }
+                return renderMapPoints();
+            }).catch(function () {
                 setMapStatus('地図データの表示中にエラーが発生しました。', 'danger');
+            });
+
+            let moveRefreshTimer = null;
+            mapAdapter.onMoveEnd(function () {
+                if (moveRefreshTimer !== null) {
+                    clearTimeout(moveRefreshTimer);
+                }
+                moveRefreshTimer = setTimeout(function () {
+                    fetchGeoJsonRecords().then(function (nextRecords) {
+                        if (!Array.isArray(nextRecords) || nextRecords.length === 0) {
+                            return;
+                        }
+                        records = nextRecords;
+                        return renderMapPoints(false);
+                    }).catch(function () {
+                        setMapStatus('地図移動後の再取得に失敗しました。', 'warning');
+                    });
+                }, 700);
             });
         });
 

--- a/html/product_thing/templates/API/display_price.php
+++ b/html/product_thing/templates/API/display_price.php
@@ -170,7 +170,7 @@ if (!empty($data) && is_array($data)) {
         const defaultZoom = 10;
         const googleMapsApiKey = <?= json_encode($googleMapsApiKey ?? null, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const useGoogleMaps = Boolean(googleMapsApiKey && window.google && window.google.maps);
-        const layerDataEndpoint = <?= json_encode($this->Url->build(['controller' => 'API', 'action' => 'layerData'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+        const layerDataEndpoint = <?= json_encode($this->Url->build(['controller' => 'LayerData', 'action' => 'layerData'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const geoJsonEndpoint = <?= json_encode($this->Url->build(['controller' => 'MlitProxy', 'action' => 'geojson'], ['fullBase' => false]), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const mapStatus = document.getElementById('mapStatus');
         let records = <?= json_encode($mapRecords, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -10,9 +10,9 @@
 <div class="container mt-5">
     <h1 class="mb-4 text-center">条件選択画面</h1>
     <div class="mb-3 text-right">
-        <?= $this->Html->link('API探索（別機能）', ['controller' => 'ApiExplorer', 'action' => 'apiExplorer'], ['class' => 'btn btn-outline-info']) ?>
+        <?= $this->Html->link('API探索（別機能）', '/api-explorer', ['class' => 'btn btn-outline-info']) ?>
     </div>
-    <?= $this->Form->create(null, ['url' => ['controller' => 'PriceSearch', 'action' => 'selectAPI'], 'class' => 'needs-validation', 'novalidate' => true]) ?>
+    <?= $this->Form->create(null, ['url' => '/price-search/select', 'class' => 'needs-validation', 'novalidate' => true]) ?>
     <div class="form-group">
         <?= $this->Form->control('prefecture', [
             'label' => ['text' => '都道府県', 'class' => 'form-label'],

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -18,6 +18,7 @@
             'label' => ['text' => '都道府県', 'class' => 'form-label'],
             'type' => 'select',
             'options' => $prefectures,
+            'default' => $selectedPrefecture ?? '',
             'class' => 'form-control',
             'empty' => '選択してください',
             'required' => true,
@@ -44,6 +45,7 @@
             'label' => ['text' => '売買年度', 'class' => 'form-label'],
             'type' => 'select',
             'options' => $years,
+            'default' => $selectedYear ?? '',
             'class' => 'form-control',
             'empty' => '選択してください',
             'required' => true,
@@ -77,7 +79,11 @@
         const year = document.getElementById('year');
         const requestCities = function () {
             if (prefecture.value) {
-                form.submit();
+                const query = new URLSearchParams({
+                    prefecture: prefecture.value,
+                    year: year.value || ''
+                });
+                window.location.href = form.action + '?' + query.toString();
             }
         };
 

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -73,10 +73,16 @@
             }
         });
 
-        // 都道府県が変更されたときにのみフォームを送信
-        document.getElementById('prefecture').addEventListener('change', function() {
-            if (this.value) form.submit();
-        });
+        const prefecture = document.getElementById('prefecture');
+        const year = document.getElementById('year');
+        const requestCities = function () {
+            if (prefecture.value && year.value) {
+                form.submit();
+            }
+        };
+
+        prefecture.addEventListener('change', requestCities);
+        year.addEventListener('change', requestCities);
     });
 </script>
 </body>

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -76,7 +76,7 @@
         const prefecture = document.getElementById('prefecture');
         const year = document.getElementById('year');
         const requestCities = function () {
-            if (prefecture.value && year.value) {
+            if (prefecture.value) {
                 form.submit();
             }
         };

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -10,9 +10,9 @@
 <div class="container mt-5">
     <h1 class="mb-4 text-center">条件選択画面</h1>
     <div class="mb-3 text-right">
-        <?= $this->Html->link('API探索（別機能）', ['controller' => 'API', 'action' => 'apiExplorer'], ['class' => 'btn btn-outline-info']) ?>
+        <?= $this->Html->link('API探索（別機能）', ['controller' => 'ApiExplorer', 'action' => 'apiExplorer'], ['class' => 'btn btn-outline-info']) ?>
     </div>
-    <?= $this->Form->create(null, ['url' => ['action' => 'selectAPI'], 'class' => 'needs-validation', 'novalidate' => true]) ?>
+    <?= $this->Form->create(null, ['url' => ['controller' => 'PriceSearch', 'action' => 'selectAPI'], 'class' => 'needs-validation', 'novalidate' => true]) ?>
     <div class="form-group">
         <?= $this->Form->control('prefecture', [
             'label' => ['text' => '都道府県', 'class' => 'form-label'],

--- a/html/product_thing/templates/layout/default.php
+++ b/html/product_thing/templates/layout/default.php
@@ -20,14 +20,14 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-success">
-<?= $this->Html->link('不動産取引情報システム', ['controller' => 'YourController', 'action' => 'selectAPI'], ['class' => 'navbar-brand']) ?>
+<?= $this->Html->link('不動産取引情報システム', '/price-search/select', ['class' => 'navbar-brand']) ?>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ml-auto">
             <li class="nav-item active">
-                <?= $this->Html->link('ホーム', ['controller' => 'API', 'action' => 'selectAPI'], ['class' => 'nav-link']) ?>
+                <?= $this->Html->link('ホーム', '/price-search/select', ['class' => 'nav-link']) ?>
             </li>
            
         </ul>

--- a/html/product_thing/tests/TestCase/Controller/MlitProxyControllerTest.php
+++ b/html/product_thing/tests/TestCase/Controller/MlitProxyControllerTest.php
@@ -21,4 +21,16 @@ class MlitProxyControllerTest extends TestCase
         $this->post('/api/mlit/transactions');
         $this->assertResponseCode(405);
     }
+
+    public function testGeojsonRequiresQueryParams(): void
+    {
+        $this->get('/api/mlit/geojson');
+        $this->assertResponseCode(400);
+    }
+
+    public function testGeojsonOnlyAllowsGet(): void
+    {
+        $this->post('/api/mlit/geojson');
+        $this->assertResponseCode(405);
+    }
 }


### PR DESCRIPTION
## 概要
Issue #5 対応として、地図マーカー表示を GeoJSON プロキシ連携に拡張し、地図移動時の再取得ロジックを追加しました。

## 変更内容
- `MlitProxyController` に `geojson()` を追加（`XIT001` + `XPT001` を結合して FeatureCollection を返却）
- `/api/mlit/geojson` ルートを追加
- `display_price.php` を更新
  - GeoJSON Feature / properties の描画に対応
  - 地図移動後にデバウンスして再取得する処理を追加
  - 初期表示時も GeoJSON エンドポイントを優先利用
- `MlitProxyControllerTest` に geojson エンドポイントの 400/405 テストを追加

## 関連Issue
- Closes #5

## 補足
- `composer test` / `composer cs-check` は既存の依存関係と PHP の互換性問題（Cake Chronos）で実行不可です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GeoJSON endpoint for richer geospatial data used by the map.

* **Improvements**
  * Map now auto-refreshes when panned/moved and fetches bbox-aware data; multiple API layers and markers load/clear dynamically.
  * Price search is now the site root and navigation links point directly to price-search pages.
  * Prefecture/year selections persist when navigating.

* **Tests**
  * Added validation tests for GeoJSON endpoint query parameters and allowed HTTP methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->