### PR TITLE
feat: split safety and school analysis screens

### DIFF
--- a/html/product_thing/config/routes.php
+++ b/html/product_thing/config/routes.php
@@ -76,6 +76,10 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/layer-data', ['controller' => 'LayerData', 'action' => 'layerData']);
         $builder->connect('/api/layer-data', ['controller' => 'LayerData', 'action' => 'layerData']);
 
+        // Area analysis URLs
+        $builder->connect('/analysis/safety', ['controller' => 'AreaAnalysis', 'action' => 'safetySurvey']);
+        $builder->connect('/analysis/school', ['controller' => 'AreaAnalysis', 'action' => 'schoolSurvey']);
+
         // MLIT proxy URLs
         $builder->connect('/api/mlit/transactions', ['controller' => 'MlitProxy', 'action' => 'transactions']);
         $builder->connect('/api/mlit/geojson', ['controller' => 'MlitProxy', 'action' => 'geojson']);

--- a/html/product_thing/src/Controller/AreaAnalysisController.php
+++ b/html/product_thing/src/Controller/AreaAnalysisController.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+class AreaAnalysisController extends AppController
+{
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->loadComponent('RequestHandler');
+    }
+
+    public function safetySurvey()
+    {
+        $this->set('area', (string)$this->request->getQuery('area', '13'));
+        $this->set('city', (string)$this->request->getQuery('city', '13101'));
+        $this->set('year', (string)$this->request->getQuery('year', '2024'));
+    }
+
+    public function schoolSurvey()
+    {
+        $this->set('area', (string)$this->request->getQuery('area', '13'));
+        $this->set('city', (string)$this->request->getQuery('city', '13101'));
+        $this->set('year', (string)$this->request->getQuery('year', '2024'));
+    }
+}

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -11,14 +11,14 @@
     <h1 class="mb-4 text-center">条件選択画面</h1>
     <div class="mb-3 d-flex justify-content-between">
         <div>
-            <?= $this->Html->link('防災調査画面', '/analysis/safety', ['class' => 'btn btn-outline-danger btn-sm']) ?>
-            <?= $this->Html->link('学校調査画面', '/analysis/school', ['class' => 'btn btn-outline-primary btn-sm']) ?>
+            <?= $this->Html->link('防災調査画面', ['controller' => 'AreaAnalysis', 'action' => 'safetySurvey'], ['class' => 'btn btn-outline-danger btn-sm']) ?>
+            <?= $this->Html->link('学校調査画面', ['controller' => 'AreaAnalysis', 'action' => 'schoolSurvey'], ['class' => 'btn btn-outline-primary btn-sm']) ?>
         </div>
         <div>
-            <?= $this->Html->link('API探索（別機能）', '/api-explorer', ['class' => 'btn btn-outline-info']) ?>
+            <?= $this->Html->link('API探索（別機能）', ['controller' => 'ApiExplorer', 'action' => 'apiExplorer'], ['class' => 'btn btn-outline-info']) ?>
         </div>
     </div>
-    <?= $this->Form->create(null, ['url' => '/price-search/select', 'class' => 'needs-validation', 'novalidate' => true]) ?>
+    <?= $this->Form->create(null, ['url' => ['controller' => 'PriceSearch', 'action' => 'selectAPI'], 'class' => 'needs-validation', 'novalidate' => true]) ?>
     <div class="form-group">
         <?= $this->Form->control('prefecture', [
             'label' => ['text' => '都道府県', 'class' => 'form-label'],

--- a/html/product_thing/templates/API/select_a_p_i.php
+++ b/html/product_thing/templates/API/select_a_p_i.php
@@ -9,8 +9,14 @@
 <body>
 <div class="container mt-5">
     <h1 class="mb-4 text-center">条件選択画面</h1>
-    <div class="mb-3 text-right">
-        <?= $this->Html->link('API探索（別機能）', '/api-explorer', ['class' => 'btn btn-outline-info']) ?>
+    <div class="mb-3 d-flex justify-content-between">
+        <div>
+            <?= $this->Html->link('防災調査画面', '/analysis/safety', ['class' => 'btn btn-outline-danger btn-sm']) ?>
+            <?= $this->Html->link('学校調査画面', '/analysis/school', ['class' => 'btn btn-outline-primary btn-sm']) ?>
+        </div>
+        <div>
+            <?= $this->Html->link('API探索（別機能）', '/api-explorer', ['class' => 'btn btn-outline-info']) ?>
+        </div>
     </div>
     <?= $this->Form->create(null, ['url' => '/price-search/select', 'class' => 'needs-validation', 'novalidate' => true]) ?>
     <div class="form-group">

--- a/html/product_thing/templates/AreaAnalysis/safety_survey.php
+++ b/html/product_thing/templates/AreaAnalysis/safety_survey.php
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>防災・規制調査</title>
+    <?= $this->Html->css('https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css') ?>
+    <link href="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.css" rel="stylesheet">
+    <style>
+        #map { height: 520px; border-radius: 8px; }
+    </style>
+</head>
+<body>
+<div class="container mt-4 mb-4">
+    <h1 class="h4">防災・規制調査画面</h1>
+    <p class="text-muted mb-2">取引価格に加えて、都市計画・用途地域・立地適正化計画を重ねて確認できます。</p>
+    <p class="small text-muted">出典：不動産情報ライブラリ（国土交通省）</p>
+    <div class="mb-3">
+        <?= $this->Html->link('価格検索へ戻る', ['controller' => 'PriceSearch', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary btn-sm']) ?>
+        <?= $this->Html->link('学校調査へ', ['controller' => 'AreaAnalysis', 'action' => 'schoolSurvey', '?' => ['area' => $area, 'city' => $city, 'year' => $year]], ['class' => 'btn btn-outline-primary btn-sm']) ?>
+    </div>
+    <div id="map"></div>
+    <div id="status" class="alert alert-secondary mt-3 mb-0">読み込み中...</div>
+</div>
+
+<script src="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', async function () {
+    const area = <?= json_encode($area, JSON_UNESCAPED_UNICODE) ?>;
+    const city = <?= json_encode($city, JSON_UNESCAPED_UNICODE) ?>;
+    const year = <?= json_encode($year, JSON_UNESCAPED_UNICODE) ?>;
+    const layerDataUrl = <?= json_encode($this->Url->build(['controller' => 'LayerData', 'action' => 'layerData'])) ?>;
+    const mlitGeoJsonUrl = <?= json_encode($this->Url->build('/api/mlit/geojson')) ?>;
+    const status = document.getElementById('status');
+
+    const map = new maplibregl.Map({
+        container: 'map',
+        style: {
+            version: 8,
+            sources: { osm: { type: 'raster', tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'], tileSize: 256 } },
+            layers: [{ id: 'osm', type: 'raster', source: 'osm' }]
+        },
+        center: [139.7671, 35.6812],
+        zoom: 11
+    });
+    map.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+    const lonToTile = (lon, z) => Math.floor((lon + 180) / 360 * Math.pow(2, z));
+    const latToTile = (lat, z) => Math.floor((1 - Math.log(Math.tan(lat * Math.PI / 180) + 1 / Math.cos(lat * Math.PI / 180)) / Math.PI) / 2 * Math.pow(2, z));
+
+    const featureCoord = function (f) {
+        if (!f || !f.geometry || !Array.isArray(f.geometry.coordinates)) return null;
+        const g = f.geometry;
+        if (g.type === 'Point') return [g.coordinates[0], g.coordinates[1]];
+        if (g.type === 'Polygon' && g.coordinates[0] && g.coordinates[0][0]) return g.coordinates[0][0];
+        if (g.type === 'MultiPolygon' && g.coordinates[0] && g.coordinates[0][0] && g.coordinates[0][0][0]) return g.coordinates[0][0][0];
+        return null;
+    };
+
+    const addFeatures = (features, color, label) => {
+        let count = 0;
+        features.forEach((f) => {
+            const c = featureCoord(f);
+            if (!c) return;
+            const p = f.properties || {};
+            new maplibregl.Marker({color}).setLngLat(c).setPopup(
+                new maplibregl.Popup({offset: 24}).setHTML('<strong>' + label + '</strong><br>' + Object.keys(p).slice(0, 4).map((k) => k + ': ' + p[k]).join('<br>'))
+            ).addTo(map);
+            count += 1;
+        });
+        return count;
+    };
+
+    const fetchLayer = async (apiId, color, label) => {
+        const center = map.getCenter();
+        const z = 14;
+        const params = new URLSearchParams({
+            api_id: apiId,
+            response_format: 'geojson',
+            z: String(z),
+            x: String(lonToTile(center.lng, z)),
+            y: String(latToTile(center.lat, z))
+        });
+        const res = await fetch(layerDataUrl + '?' + params.toString());
+        if (!res.ok) return 0;
+        const payload = await res.json();
+        const features = payload && payload.body && Array.isArray(payload.body.features) ? payload.body.features : [];
+        return addFeatures(features, color, label);
+    };
+
+    map.on('load', async function () {
+        try {
+            const txRes = await fetch(mlitGeoJsonUrl + '?area=' + encodeURIComponent(area) + '&city=' + encodeURIComponent(city) + '&year=' + encodeURIComponent(year));
+            const txGeo = await txRes.json();
+            const txFeatures = Array.isArray(txGeo.features) ? txGeo.features : [];
+            const txCount = addFeatures(txFeatures, '#16a34a', '取引価格');
+
+            const c1 = await fetchLayer('XKT001', '#4b5563', '都市計画区域');
+            const c2 = await fetchLayer('XKT002', '#2563eb', '用途地域');
+            const c3 = await fetchLayer('XKT003', '#0ea5e9', '立地適正化計画');
+
+            status.className = 'alert alert-success mt-3 mb-0';
+            status.textContent = '取引価格: ' + txCount + '件 / 都市計画: ' + c1 + '件 / 用途地域: ' + c2 + '件 / 立地適正化: ' + c3 + '件';
+        } catch (e) {
+            status.className = 'alert alert-danger mt-3 mb-0';
+            status.textContent = 'データ取得に失敗しました。';
+        }
+    });
+});
+</script>
+</body>
+</html>

--- a/html/product_thing/templates/AreaAnalysis/safety_survey.php
+++ b/html/product_thing/templates/AreaAnalysis/safety_survey.php
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const city = <?= json_encode($city, JSON_UNESCAPED_UNICODE) ?>;
     const year = <?= json_encode($year, JSON_UNESCAPED_UNICODE) ?>;
     const layerDataUrl = <?= json_encode($this->Url->build(['controller' => 'LayerData', 'action' => 'layerData'])) ?>;
-    const mlitGeoJsonUrl = <?= json_encode($this->Url->build('/api/mlit/geojson')) ?>;
+    const mlitGeoJsonUrl = <?= json_encode($this->Url->build(['controller' => 'MlitProxy', 'action' => 'geojson'])) ?>;
     const status = document.getElementById('status');
 
     const map = new maplibregl.Map({

--- a/html/product_thing/templates/AreaAnalysis/school_survey.php
+++ b/html/product_thing/templates/AreaAnalysis/school_survey.php
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>学校・生活調査</title>
+    <?= $this->Html->css('https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css') ?>
+    <link href="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.css" rel="stylesheet">
+    <style>
+        #map { height: 520px; border-radius: 8px; }
+    </style>
+</head>
+<body>
+<div class="container mt-4 mb-4">
+    <h1 class="h4">学校・生活調査画面</h1>
+    <p class="text-muted mb-2">取引価格に加えて、学校区・学校・保育園・医療/福祉施設を重ねて確認できます。</p>
+    <p class="small text-muted">出典：不動産情報ライブラリ（国土交通省）</p>
+    <div class="mb-3">
+        <?= $this->Html->link('価格検索へ戻る', ['controller' => 'PriceSearch', 'action' => 'selectAPI'], ['class' => 'btn btn-outline-secondary btn-sm']) ?>
+        <?= $this->Html->link('防災調査へ', ['controller' => 'AreaAnalysis', 'action' => 'safetySurvey', '?' => ['area' => $area, 'city' => $city, 'year' => $year]], ['class' => 'btn btn-outline-primary btn-sm']) ?>
+    </div>
+    <div id="map"></div>
+    <div id="status" class="alert alert-secondary mt-3 mb-0">読み込み中...</div>
+</div>
+
+<script src="https://unpkg.com/maplibre-gl@5.3.0/dist/maplibre-gl.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', async function () {
+    const area = <?= json_encode($area, JSON_UNESCAPED_UNICODE) ?>;
+    const city = <?= json_encode($city, JSON_UNESCAPED_UNICODE) ?>;
+    const year = <?= json_encode($year, JSON_UNESCAPED_UNICODE) ?>;
+    const layerDataUrl = <?= json_encode($this->Url->build(['controller' => 'LayerData', 'action' => 'layerData'])) ?>;
+    const mlitGeoJsonUrl = <?= json_encode($this->Url->build('/api/mlit/geojson')) ?>;
+    const status = document.getElementById('status');
+
+    const map = new maplibregl.Map({
+        container: 'map',
+        style: {
+            version: 8,
+            sources: { osm: { type: 'raster', tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'], tileSize: 256 } },
+            layers: [{ id: 'osm', type: 'raster', source: 'osm' }]
+        },
+        center: [139.7671, 35.6812],
+        zoom: 11
+    });
+    map.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+    const lonToTile = (lon, z) => Math.floor((lon + 180) / 360 * Math.pow(2, z));
+    const latToTile = (lat, z) => Math.floor((1 - Math.log(Math.tan(lat * Math.PI / 180) + 1 / Math.cos(lat * Math.PI / 180)) / Math.PI) / 2 * Math.pow(2, z));
+
+    const featureCoord = function (f) {
+        if (!f || !f.geometry || !Array.isArray(f.geometry.coordinates)) return null;
+        const g = f.geometry;
+        if (g.type === 'Point') return [g.coordinates[0], g.coordinates[1]];
+        if (g.type === 'Polygon' && g.coordinates[0] && g.coordinates[0][0]) return g.coordinates[0][0];
+        if (g.type === 'MultiPolygon' && g.coordinates[0] && g.coordinates[0][0] && g.coordinates[0][0][0]) return g.coordinates[0][0][0];
+        return null;
+    };
+
+    const addFeatures = (features, color, label) => {
+        let count = 0;
+        features.forEach((f) => {
+            const c = featureCoord(f);
+            if (!c) return;
+            const p = f.properties || {};
+            new maplibregl.Marker({color}).setLngLat(c).setPopup(
+                new maplibregl.Popup({offset: 24}).setHTML('<strong>' + label + '</strong><br>' + Object.keys(p).slice(0, 4).map((k) => k + ': ' + p[k]).join('<br>'))
+            ).addTo(map);
+            count += 1;
+        });
+        return count;
+    };
+
+    const fetchLayer = async (apiId, color, label) => {
+        const center = map.getCenter();
+        const z = 14;
+        const params = new URLSearchParams({
+            api_id: apiId,
+            response_format: 'geojson',
+            z: String(z),
+            x: String(lonToTile(center.lng, z)),
+            y: String(latToTile(center.lat, z))
+        });
+        const res = await fetch(layerDataUrl + '?' + params.toString());
+        if (!res.ok) return 0;
+        const payload = await res.json();
+        const features = payload && payload.body && Array.isArray(payload.body.features) ? payload.body.features : [];
+        return addFeatures(features, color, label);
+    };
+
+    map.on('load', async function () {
+        try {
+            const txRes = await fetch(mlitGeoJsonUrl + '?area=' + encodeURIComponent(area) + '&city=' + encodeURIComponent(city) + '&year=' + encodeURIComponent(year));
+            const txGeo = await txRes.json();
+            const txFeatures = Array.isArray(txGeo.features) ? txGeo.features : [];
+            const txCount = addFeatures(txFeatures, '#16a34a', '取引価格');
+
+            const c1 = await fetchLayer('XKT004', '#2563eb', '小学校区');
+            const c2 = await fetchLayer('XKT005', '#0ea5e9', '中学校区');
+            const c3 = await fetchLayer('XKT006', '#14b8a6', '学校');
+            const c4 = await fetchLayer('XKT007', '#10b981', '保育園・幼稚園');
+            const c5 = await fetchLayer('XKT010', '#ef4444', '医療機関');
+            const c6 = await fetchLayer('XKT011', '#ec4899', '福祉施設');
+
+            status.className = 'alert alert-success mt-3 mb-0';
+            status.textContent = '取引価格: ' + txCount + '件 / 小学校区: ' + c1 + '件 / 中学校区: ' + c2 + '件 / 学校: ' + c3 + '件 / 保育園等: ' + c4 + '件 / 医療: ' + c5 + '件 / 福祉: ' + c6 + '件';
+        } catch (e) {
+            status.className = 'alert alert-danger mt-3 mb-0';
+            status.textContent = 'データ取得に失敗しました。';
+        }
+    });
+});
+</script>
+</body>
+</html>

--- a/html/product_thing/templates/AreaAnalysis/school_survey.php
+++ b/html/product_thing/templates/AreaAnalysis/school_survey.php
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const city = <?= json_encode($city, JSON_UNESCAPED_UNICODE) ?>;
     const year = <?= json_encode($year, JSON_UNESCAPED_UNICODE) ?>;
     const layerDataUrl = <?= json_encode($this->Url->build(['controller' => 'LayerData', 'action' => 'layerData'])) ?>;
-    const mlitGeoJsonUrl = <?= json_encode($this->Url->build('/api/mlit/geojson')) ?>;
+    const mlitGeoJsonUrl = <?= json_encode($this->Url->build(['controller' => 'MlitProxy', 'action' => 'geojson'])) ?>;
     const status = document.getElementById('status');
 
     const map = new maplibregl.Map({


### PR DESCRIPTION
Adds separate controller/template screens so analysis is not only in the transaction price page. Safety screen includes XKT001/XKT002/XKT003 layers. School screen includes XKT004/XKT005/XKT006/XKT007/XKT010/XKT011 layers. Routes /analysis/safety and /analysis/school were added, and links from the selection page were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Safety Survey screen with an interactive map displaying disaster prevention and regulation data layers with property markers and information popups
  * Added School Survey screen featuring an interactive map showing educational and community data with dynamic marker placement and details
  * Enhanced navigation to provide quick access to both new survey screens and existing analysis tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->